### PR TITLE
Use structured log record for SD card writes

### DIFF
--- a/robotrace_v2/Core/Inc/SDcard.h
+++ b/robotrace_v2/Core/Inc/SDcard.h
@@ -17,7 +17,23 @@
 #define LOG_NUM_16BIT 7
 #define LOG_NUM_32BIT 1
 #define LOG_NUM_FLOAT 1
-#define LOG_SIZE (LOG_NUM_8BIT * sizeof(uint8_t)) + (LOG_NUM_16BIT * sizeof(uint16_t)) + (LOG_NUM_32BIT * sizeof(uint32_t)) + (LOG_NUM_FLOAT * sizeof(float))
+
+typedef struct
+{
+	uint8_t targetSpeed;	// 目標速度
+	uint8_t courseMarker;	// コースマーカー種別
+	uint16_t time;		// 経過時間[ms]
+	int16_t speed;		// 現在速度
+	uint16_t optimalIndex;	// ショートカット用インデックス
+	int16_t currentL;	// 左モータ電流×10000
+	int16_t currentR;	// 右モータ電流×10000
+	int16_t lineTracePwm;	// ライントレースPWM
+	int16_t veloPwm;		// 速度制御PWM
+	uint32_t encTotal;	// 総エンコーダカウント
+	float gyroZ;		// ジャイロZ軸角速度
+} LogRecord;	// 走行ログ1件分を保持する構造体
+
+#define LOG_SIZE sizeof(LogRecord)
 
 #endif
 
@@ -43,7 +59,7 @@ void endLog(void);
 void writeMarkerPos(uint32_t distance, uint8_t marker);
 void initLog(void);
 #ifdef LOG_RUNNING_WRITE
-void writeLogBufferPuts(uint8_t c, uint8_t s, uint8_t i, uint8_t f, ...);
+void writeLogBufferPuts(const LogRecord *rec);
 void writeLogPuts(void);
 void send8bit(uint8_t data);
 void send16bit(uint16_t data);

--- a/robotrace_v2/Core/Src/timer.c
+++ b/robotrace_v2/Core/Src/timer.c
@@ -164,31 +164,24 @@ void Interrupt1ms(void)
 			{
 				// CALCDISTANCEごとにログを保存
 #ifdef LOG_RUNNING_WRITE
-				writeLogBufferPuts(
-					LOG_NUM_8BIT,
-					LOG_NUM_16BIT,
-					LOG_NUM_32BIT,
-					LOG_NUM_FLOAT,
-					// 8bit
-					targetSpeed,
-					courseMarker,
-					// 16bit
-					cntRun,
-					encCurrentN,
-					optimalIndex,
-					(int16_t)(motorCurrentL * 10000),
-					(int16_t)(motorCurrentR * 10000),
-					lineTraceCtrl.pwm,
-					veloCtrl.pwm,
-					// 32bit
-					encTotalOptimal,
-					// float型
-					BMI088val.gyro.z);
+				LogRecord rec;	// ログ記録用構造体
+				rec.targetSpeed = targetSpeed;	// 目標速度
+				rec.courseMarker = courseMarker;	// コースマーカー
+				rec.time = (uint16_t)cntRun;	// 経過時間
+				rec.speed = encCurrentN;	// 現在速度
+				rec.optimalIndex = optimalIndex;	// ショートカットインデックス
+				rec.currentL = (int16_t)(motorCurrentL * 10000);	// 左モータ電流
+				rec.currentR = (int16_t)(motorCurrentR * 10000);	// 右モータ電流
+				rec.lineTracePwm = lineTraceCtrl.pwm;	// ライントレースPWM
+				rec.veloPwm = veloCtrl.pwm;	// 速度制御PWM
+				rec.encTotal = encTotalOptimal;	// 総エンコーダカウント
+				rec.gyroZ = BMI088val.gyro.z;	// ジャイロ角速度
+				writeLogBufferPuts(&rec);	// 構造体をバッファに書き込む
 #else
 				writeLogBufferPrint(); // バッファにログを保存
 #endif
-				cntLog = 0;
-				encLog = 0;
+				cntLog = 0;              // ログ間隔カウンタをリセット
+				encLog = 0;              // ログ距離カウンタをリセット
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- add `LogRecord` struct to represent one log entry
- write log entries via `writeLogBufferPuts(const LogRecord *rec)` using `memcpy`
- update timer logging to fill `LogRecord` before writing
- restore tab-based indentation for new log record code
- add explanatory comments to log record handling
- document purpose of `LogRecord` struct

## Testing
- `gcc -c robotrace_v2/Core/Src/SDcard.c -Irobotrace_v2/Core/Inc` *(fails: stm32f4xx_hal.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b2c92d880883238edf2d508c6de0fc