### PR TITLE
Refactor HEX_LOG handling into dedicated function

### DIFF
--- a/robotrace_v2/Core/Src/setup.c
+++ b/robotrace_v2/Core/Src/setup.c
@@ -5,7 +5,7 @@
 //====================================//
 // グローバル変数の宣言
 //====================================//
-uint8_t start = 0; // 0:セットアップ中	1:セットアップ完了
+	uint8_t start = 0; // 0:セットアップ中	1:セットアップ完了
 
 // タイマ関連
 uint16_t cntSetup1 = 0;		  // セットアップで使用
@@ -20,7 +20,7 @@ int8_t pushLR = 0;
 int8_t pushUD = 0;
 
 // パターン関連
-uint8_t push1 = 0;
+	uint8_t push1 = 0;
 int16_t patternDisplay = 0;
 int16_t patternSensors = 1;
 int16_t beforeSensors = 0;
@@ -39,8 +39,8 @@ int16_t patternCalibration = 1;
 int16_t patternClick = 1;
 
 // フラグ関連
-uint8_t motor_test = 0;
-uint8_t trace_test = 0;
+	uint8_t motor_test = 0;
+	uint8_t trace_test = 0;
 int8_t clickStart = 0;
 static uint8_t beforeMotorTest = 0;  // モータテストの状態を保存
 
@@ -56,6 +56,7 @@ static void setup_pid_dist(void); // ゲイン調整(距離)
 static void setup_pid_angle(void); // ゲイン調整(角度)
 static void setup_pid_angular(void); // ゲイン調整(角速度)
 static void setup_pid_speed(void); // ゲイン調整(速度)
+static void setup_log(void); // ログ解析と表示を制御
 /////////////////////////////////////////////////////////////////////////////////////
 // モジュール名 setup_sensors
 // 処理概要     センサ表示とテストメニューを制御
@@ -752,8 +753,118 @@ static void setup_pid_angle(void)
 			dataTuningLR(&yawCtrl.kd, 1, 0, 255);
 			break;
 		}
-	}
+        }
 }
+///////////////////////////////////////////////////////////////////////////////////////
+// モジュール名 setup_log
+// 処理概要     ログ解析表示と操作を制御
+// 引数         なし
+// 戻り値       なし
+///////////////////////////////////////////////////////////////////////////////////////
+static void setup_log(void)
+{
+	static int16_t y = 0, offset, ret = 0; // y: 選択中のログNo, offset: 表示開始位置, ret: 解析結果
+	uint8_t i, j; // i: 表示ループ用, j: スイッチ入力用
+
+        if (patternDisplay != beforeHEX)
+        {
+                // 切替時に実行
+                ssd1306_printf(Font_6x8, "microSD  ");
+                y = endFileIndex + 1; // 前回解析したログを初期選択
+                ssd1306_SetCursor(30, 16);
+                ssd1306_printf(Font_6x8, "Dist <");
+                ssd1306_SetCursor(80, 16);
+                ssd1306_printf(Font_6x8, "> XYcalc");
+                ssd1306_SetCursor(46, 25);
+                ssd1306_printf(Font_6x8, "indexD:%4d", numPPADarry);
+                ssd1306_SetCursor(46, 34);
+                ssd1306_printf(Font_6x8, "indexS:%4d", indexSC);
+                ssd1306_SetCursor(46, 43);
+                ssd1306_printf(Font_6x8, "marker:%4d", numPPAMarry);
+        }
+
+        ssd1306_SetCursor(0, 16);
+        ssd1306_printf(Font_6x8, "%4d", fileNumbers[fileIndexLog]);
+
+        dataTuningUD(&y, 1, 0, endFileIndex + 1); // ログNoを上下スイッチで選択
+
+        j = swValTact; // タクトスイッチの状態を取得
+        if (j == SW_LEFT || j == SW_RIGHT) // 左右スイッチで解析を実行
+        {
+                ssd1306_FillRectangle(30, 25, 127, 63, Black); // メイン表示空白埋め
+                ssd1306_SetCursor(46, 38);
+                ssd1306_printf(Font_6x8, "Calculating");
+                ssd1306_UpdateScreen(); // グラフィック液晶更新
+
+                if (y == endFileIndex + 1)
+                {
+                        y = fileIndexLog; // 前回解析したログを再解析
+                }
+
+                if (j == SW_LEFT)
+                {
+                        // 距離基準解析
+                        ret = readLogDistance(fileNumbers[y]);
+                }
+                else if (j == SW_RIGHT)
+                {
+                        // ショートカット解析
+                        ret = calcXYcies(fileNumbers[y]);
+                }
+
+                if (ret > 0)
+                {
+                        optimalIndex = 0; // 解析結果インデックスをリセット
+                        ssd1306_FillRectangle(30, 25, 127, 63, Black); // メイン表示空白埋め
+                        ssd1306_SetCursor(46, 25);
+                        ssd1306_printf(Font_6x8, "indexD:%4d", numPPADarry);
+                        ssd1306_SetCursor(46, 34);
+                        ssd1306_printf(Font_6x8, "indexS:%4d", indexSC);
+                        ssd1306_SetCursor(46, 43);
+                        ssd1306_printf(Font_6x8, "marker:%4d", numPPAMarry);
+                }
+                else
+                {
+                        ssd1306_FillRectangle(30, 25, 127, 63, Black); // メイン表示空白埋め
+                        ssd1306_SetCursor(64, 30);
+                        ssd1306_printf(Font_6x8, "Error");
+                        ssd1306_SetCursor(61, 38);
+                        ssd1306_printf(Font_6x8, "code:%d", ret);
+                }
+        }
+
+        // ログNoの選択処理
+        for (i = 0; i < 5; i++)
+        {
+                // 前回解析ログNoを選択しているとき
+                if (y == endFileIndex + 1)
+                {
+                        ssd1306_SetCursor(0, 16);
+                        ssd1306_printfB(Font_6x8, "%4d", fileNumbers[fileIndexLog]);
+                }
+
+                // ログNoを選択するとき
+                offset = endFileIndex - y - 4; // 前回解析Noと一番下のNoを除く表示中の4つ中一番上のインデックスを計算
+                ssd1306_SetCursor(0, 24 + (8 * i));
+
+                // 最新4つのデータを表示するとき
+                if (offset < 0)
+                {
+                        offset = 0;
+                }
+
+                if (endFileIndex - y == i || (i == 4 && offset > 0))
+                {
+                        // 選択したログNoをハイライト表示
+                        ssd1306_printfB(Font_6x8, "%4d", fileNumbers[endFileIndex - offset - i]);
+                }
+                else
+                {
+                        ssd1306_printf(Font_6x8, "%4d", fileNumbers[endFileIndex - offset - i]);
+                }
+        }
+}
+
 ///////////////////////////////////////////////////////////////////////////////////////
 // モジュール名 setup
 // 処理概要     走行前設定
@@ -762,9 +873,9 @@ static void setup_pid_angle(void)
 ///////////////////////////////////////////////////////////////////////////////////////
 void setup(void)
 {
-	uint8_t cntLed, i, j, k;
-	static uint8_t beforePparam, beforeBATLV;
-	static int16_t x = 0, y = 0, offset, ret = 0;
+        uint8_t cntLed, i, j, k;
+        static uint8_t beforePparam, beforeBATLV;
+        static int16_t x = 0;
 
 	SchmittBatery(); // バッテリレベルを取得
 	if (batteryLevel != beforeBATLV)
@@ -1114,113 +1225,16 @@ void setup(void)
 		setup_sensors(); // センサ表示とテストメニューを制御
 		break;
 	}
-	//------------------------------------------------------------------
-	// Log analysis
-	//------------------------------------------------------------------
-	case HEX_LOG:
-	{
-		if (patternDisplay != beforeHEX)
-		{
-			// 切替時に実行
-			ssd1306_printf(Font_6x8, "microSD  ");
-			y = endFileIndex + 1;
-			ssd1306_SetCursor(30, 16);
-			ssd1306_printf(Font_6x8, "Dist <");
-			ssd1306_SetCursor(80, 16);
-			ssd1306_printf(Font_6x8, "> XYcalc");
-			ssd1306_SetCursor(46, 25);
-			ssd1306_printf(Font_6x8, "indexD:%4d", numPPADarry);
-			ssd1306_SetCursor(46, 34);
-			ssd1306_printf(Font_6x8, "indexS:%4d", indexSC);
-			ssd1306_SetCursor(46, 43);
-			ssd1306_printf(Font_6x8, "marker:%4d", numPPAMarry);
-		}
-
-		ssd1306_SetCursor(0, 16);
-		ssd1306_printf(Font_6x8, "%4d", fileNumbers[fileIndexLog]);
-
-		dataTuningUD(&y, 1, 0, endFileIndex + 1);
-
-		j = swValTact;
-		if (j == SW_LEFT || j == SW_RIGHT)
-		{
-			ssd1306_FillRectangle(30, 25, 127, 63, Black); // メイン表示空白埋め
-			ssd1306_SetCursor(46, 38);
-			ssd1306_printf(Font_6x8, "Calculating");
-			ssd1306_UpdateScreen(); // グラフィック液晶更新
-
-			if (y == endFileIndex + 1)
-			{
-				y = fileIndexLog;
-			}
-
-			if (j == SW_LEFT)
-			{
-				// 距離基準解析
-				ret = readLogDistance(fileNumbers[y]);
-			}
-			else if (j == SW_RIGHT)
-			{
-				// ショートカット解析
-				ret = calcXYcies(fileNumbers[y]);
-			}
-
-			if (ret > 0)
-			{
-				optimalIndex = 0;
-				ssd1306_FillRectangle(30, 25, 127, 63, Black); // メイン表示空白埋め
-				ssd1306_SetCursor(46, 25);
-				ssd1306_printf(Font_6x8, "indexD:%4d", numPPADarry);
-				ssd1306_SetCursor(46, 34);
-				ssd1306_printf(Font_6x8, "indexS:%4d", indexSC);
-				ssd1306_SetCursor(46, 43);
-				ssd1306_printf(Font_6x8, "marker:%4d", numPPAMarry);
-			}
-			else
-			{
-				ssd1306_FillRectangle(30, 25, 127, 63, Black); // メイン表示空白埋め
-				ssd1306_SetCursor(64, 30);
-				ssd1306_printf(Font_6x8, "Error");
-				ssd1306_SetCursor(61, 38);
-				ssd1306_printf(Font_6x8, "code:%d", ret);
-			}
-		}
-
-		// ログNoの選択処理
-		for (i = 0; i < 5; i++)
-		{
-			// 前回解析ログNoを選択しているとき
-			if (y == endFileIndex + 1)
-			{
-				ssd1306_SetCursor(0, 16);
-				ssd1306_printfB(Font_6x8, "%4d", fileNumbers[fileIndexLog]);
-			}
-
-			// ログNoを選択するとき
-			offset = endFileIndex - y - 4; // 前回解析Noと一番下のNoを除く表示中の4つ中一番上のインデックスを計算
-			ssd1306_SetCursor(0, 24 + (8 * i));
-
-			// 最新4つのデータを表示するとき
-			if (offset < 0)
-			{
-				offset = 0;
-			}
-
-			if (endFileIndex - y == i || (i == 4 && offset > 0))
-			{
-				// 選択したログNoをハイライト表示
-				ssd1306_printfB(Font_6x8, "%4d", fileNumbers[endFileIndex - offset - i]);
-			}
-			else
-			{
-				ssd1306_printf(Font_6x8, "%4d", fileNumbers[endFileIndex - offset - i]);
-			}
-		}
-
-		break;
-	}
-	//------------------------------------------------------------------
-	// キャリブレーション(ラインセンサ)
+        //------------------------------------------------------------------
+        // Log analysis
+        //------------------------------------------------------------------
+        case HEX_LOG:
+        {
+                setup_log(); // ログ解析表示と操作を制御
+                break;
+        }
+        //------------------------------------------------------------------
+        // キャリブレーション(ラインセンサ)
 	//------------------------------------------------------------------
 	case HEX_CALIBRATION:
 	{


### PR DESCRIPTION
## Summary
- extract HEX_LOG switch case into `setup_log` function
- add comments explaining log selection and switch handling
- keep `setup_log` internal and remove unused header prototype
- document log analysis controls and index resets

## Testing
- `gcc -std=c11 -Wall -fsyntax-only -I robotrace_v2/Core/Inc -I robotrace_v2/Drivers/STM32F4xx_HAL_Driver/Inc -I robotrace_v2/Drivers/STM32F4xx_HAL_Driver/Inc/Legacy -I robotrace_v2/Drivers/CMSIS/Device/ST/STM32F4xx/Include -I robotrace_v2/Drivers/CMSIS/Include robotrace_v2/Core/Src/setup.c 2>&1 | head -n 20` *(fails: Please select first the target STM32F4xx device used in your application)*

------
https://chatgpt.com/codex/tasks/task_e_68b316e6c5748323bb13798f47a43597