### PR TITLE
バッファ残量監視と枯渇時待機処理の追加

### DIFF
--- a/robotrace_v2/Core/Inc/SDcard.h
+++ b/robotrace_v2/Core/Inc/SDcard.h
@@ -32,6 +32,7 @@
 extern int16_t fileNumbers[1000],fileIndexLog, endFileIndex;
 extern uint8_t cntLog;
 extern int32_t encLog;
+extern volatile uint8_t freeBufCount; // 未使用バッファ数を監視
 //====================================//
 // プロトタイプ宣言
 //====================================//

--- a/robotrace_v2/Core/Src/SDcard.c
+++ b/robotrace_v2/Core/Src/SDcard.c
@@ -227,20 +227,20 @@ void writeMarkerPos(uint32_t distance, uint8_t marker)
 /////////////////////////////////////////////////////////////////////
 void initLog(void)
 {
-        FRESULT fresult;
+    FRESULT fresult;
 #ifdef LOG_RUNNING_WRITE
-        fresult = f_open(&fil_W, "temp", FA_OPEN_ALWAYS | FA_WRITE); // create file
-        freeBufCount = LOG_BUFFER_COUNT - 1;                          // 未使用バッファ数を初期化
-        activeIndex = 0;                                              // バッファ番号を初期化
-        flushIndex = 0;                                               // フラッシュ待ち番号を初期化
-        logBuffIndex = 0;                                             // 書込位置を初期化
-        activeBuf = logBuffer[0];                                     // アクティブバッファを初期化
-        sendSD = false;                                               // 書き込み要求をリセット
+	fresult = f_open(&fil_W, "temp", FA_OPEN_ALWAYS | FA_WRITE); // create file
+	freeBufCount = LOG_BUFFER_COUNT - 1;                          // 未使用バッファ数を初期化
+	activeIndex = 0;                                              // バッファ番号を初期化
+	flushIndex = 0;                                               // フラッシュ待ち番号を初期化
+	logBuffIndex = 0;                                             // 書込位置を初期化
+	activeBuf = logBuffer[0];                                     // アクティブバッファを初期化
+	sendSD = false;                                               // 書き込み要求をリセット
 #else
-        // 構造体配列の初期化
-        memset(&logVal, 0, sizeof(logData) * BUFFER_SIZW_LOG);
-        memset(&markerVal, 0, sizeof(markerData) * BUFFER_SIZW_MARKER);
-        logValIndex = 0;
+	// 構造体配列の初期化
+	memset(&logVal, 0, sizeof(logData) * BUFFER_SIZW_LOG);
+	memset(&markerVal, 0, sizeof(markerData) * BUFFER_SIZW_MARKER);
+	logValIndex = 0;
 	markerValIndex = 0;
 #endif
 }
@@ -281,17 +281,16 @@ void writeLogBufferPuts(uint8_t c, uint8_t s, uint8_t i, uint8_t f, ...)
 		cntSend++; // 書き込み回数をカウント
 
 		// バッファ容量を超えたらリングバッファを進める
-                if (logBuffIndex + LOG_SIZE > LOG_BUFFER_SIZE)
-                {
-                        // バッファが枯渇している場合は空きができるまで待機
-                        while (freeBufCount == 0)
-                                ;                                       // 空きバッファ待機
-                        logBuffIndex = 0;                                // 書込位置をリセット
-                        activeIndex = (activeIndex + 1) % LOG_BUFFER_COUNT; // リングバッファ切替
-                        activeBuf = logBuffer[activeIndex];              // アクティブバッファ更新
-                        freeBufCount--;                                   // 使用バッファを減算
-                        sendSD = true;                                   // SD書き込みを要求
-                }
+		if (logBuffIndex + LOG_SIZE > LOG_BUFFER_SIZE)
+		{
+			// バッファが枯渇している場合は空きができるまで待機
+			while (freeBufCount == 0);							// 空きバッファ待機
+			logBuffIndex = 0;									// 書込位置をリセット
+			activeIndex = (activeIndex + 1) % LOG_BUFFER_COUNT; // リングバッファ切替
+			activeBuf = logBuffer[activeIndex];					// アクティブバッファ更新
+			freeBufCount--;										// 使用バッファを減算
+			sendSD = true;										// SD書き込みを要求
+		}
 	}
 }
 #endif
@@ -311,12 +310,12 @@ void writeLogPuts(void)
 		if (sendSD) // 書き込み要求がある場合
 		{
 			// 未書き込みバッファをSDカードへ転送
-                        f_write(&fil_W, logBuffer[flushIndex], LOG_BUFFER_SIZE, &writtenlog); // リングバッファから書き出し
-                        freeBufCount++;                                                       // バッファ解放
-                        flushIndex = (flushIndex + 1) % LOG_BUFFER_COUNT;                     // 次のバッファへ
-                        if (flushIndex == activeIndex)                                       // 全バッファ書き込み済みなら終了
-                                sendSD = false;                                              // 書き込み要求を解除
-                }
+			f_write(&fil_W, logBuffer[flushIndex], LOG_BUFFER_SIZE, &writtenlog);	// リングバッファから書き出し
+			freeBufCount++;															// バッファ解放
+			flushIndex = (flushIndex + 1) % LOG_BUFFER_COUNT;						// 次のバッファへ
+			if (flushIndex == activeIndex)											// 全バッファ書き込み済みなら終了
+				sendSD = false;														// 書き込み要求を解除
+			}
         }
 }
 #endif
@@ -426,10 +425,10 @@ void endLog(void)
 	uint32_t logval32[10];
 	float logvalf[10];
 
-	while (sendSD)                                                                          // 溜まったバッファをすべて書き出す
-		writeLogPuts();                                                                 // リングバッファ書き込み
+	while (sendSD)														// 溜まったバッファをすべて書き出す
+		writeLogPuts();													// リングバッファ書き込み
 	f_write(&fil_W, logBuffer[activeIndex], logBuffIndex, &writtenlog); // 残りのデータを送信
-	f_close(&fil_W);                                                                        // 一時ファイルを閉じる
+	f_close(&fil_W);													// 一時ファイルを閉じる
 
 	createLog(); // ログファイル(csv)を作成
 

--- a/robotrace_v2/Core/Src/SDcard.c
+++ b/robotrace_v2/Core/Src/SDcard.c
@@ -18,7 +18,7 @@ uint8_t columnTitle[512] = "", formatLog[256] = "";
 // ログバッファ
 #ifdef LOG_RUNNING_WRITE
 #define LOG_BUFFER_SIZE (512 * 4) // バッファ増量
-#define LOG_BUFFER_COUNT 4        // バッファ増量
+#define LOG_BUFFER_COUNT 8        // バッファ数増量
 uint8_t logBuffer[LOG_BUFFER_COUNT][LOG_BUFFER_SIZE]; // バッファ増量
 uint8_t *activeBuf = logBuffer[0]; // 書き込み中のバッファ
 uint8_t activeIndex = 0;          // 現在のバッファ番号
@@ -27,6 +27,7 @@ int16_t logBuffIndex = 0;          // 一時記録バッファ書込アドレス
 bool sendSD = false;               // SD書き込み要求フラグ
 uint16_t cntSend = 0;
 uint8_t *logaddress;
+volatile uint8_t freeBufCount = LOG_BUFFER_COUNT - 1; // 未使用バッファ数を管理
 #else
 typedef struct
 {
@@ -226,14 +227,20 @@ void writeMarkerPos(uint32_t distance, uint8_t marker)
 /////////////////////////////////////////////////////////////////////
 void initLog(void)
 {
-	FRESULT fresult;
+        FRESULT fresult;
 #ifdef LOG_RUNNING_WRITE
-	fresult = f_open(&fil_W, "temp", FA_OPEN_ALWAYS | FA_WRITE); // create file
+        fresult = f_open(&fil_W, "temp", FA_OPEN_ALWAYS | FA_WRITE); // create file
+        freeBufCount = LOG_BUFFER_COUNT - 1;                          // 未使用バッファ数を初期化
+        activeIndex = 0;                                              // バッファ番号を初期化
+        flushIndex = 0;                                               // フラッシュ待ち番号を初期化
+        logBuffIndex = 0;                                             // 書込位置を初期化
+        activeBuf = logBuffer[0];                                     // アクティブバッファを初期化
+        sendSD = false;                                               // 書き込み要求をリセット
 #else
-	// 構造体配列の初期化
-	memset(&logVal, 0, sizeof(logData) * BUFFER_SIZW_LOG);
-	memset(&markerVal, 0, sizeof(markerData) * BUFFER_SIZW_MARKER);
-	logValIndex = 0;
+        // 構造体配列の初期化
+        memset(&logVal, 0, sizeof(logData) * BUFFER_SIZW_LOG);
+        memset(&markerVal, 0, sizeof(markerData) * BUFFER_SIZW_MARKER);
+        logValIndex = 0;
 	markerValIndex = 0;
 #endif
 }
@@ -274,15 +281,17 @@ void writeLogBufferPuts(uint8_t c, uint8_t s, uint8_t i, uint8_t f, ...)
 		cntSend++; // 書き込み回数をカウント
 
 		// バッファ容量を超えたらリングバッファを進める
-		if (logBuffIndex + LOG_SIZE > LOG_BUFFER_SIZE)
-		{
-			logBuffIndex = 0;                                        // 書込位置をリセット
-			activeIndex = (activeIndex + 1) % LOG_BUFFER_COUNT;      // リングバッファ切替
-			if (activeIndex == flushIndex)                           // 追い越し防止
-				flushIndex = (flushIndex + 1) % LOG_BUFFER_COUNT; // 最古のデータを更新
-			activeBuf = logBuffer[activeIndex];                      // アクティブバッファ更新
-			sendSD = true;                                           // SD書き込みを要求
-		}
+                if (logBuffIndex + LOG_SIZE > LOG_BUFFER_SIZE)
+                {
+                        // バッファが枯渇している場合は空きができるまで待機
+                        while (freeBufCount == 0)
+                                ;                                       // 空きバッファ待機
+                        logBuffIndex = 0;                                // 書込位置をリセット
+                        activeIndex = (activeIndex + 1) % LOG_BUFFER_COUNT; // リングバッファ切替
+                        activeBuf = logBuffer[activeIndex];              // アクティブバッファ更新
+                        freeBufCount--;                                   // 使用バッファを減算
+                        sendSD = true;                                   // SD書き込みを要求
+                }
 	}
 }
 #endif
@@ -302,12 +311,13 @@ void writeLogPuts(void)
 		if (sendSD) // 書き込み要求がある場合
 		{
 			// 未書き込みバッファをSDカードへ転送
-			f_write(&fil_W, logBuffer[flushIndex], LOG_BUFFER_SIZE, &writtenlog); // リングバッファから書き出し
-			flushIndex = (flushIndex + 1) % LOG_BUFFER_COUNT;                     // 次のバッファへ
-			if (flushIndex == activeIndex)                                       // 全バッファ書き込み済みなら終了
-				sendSD = false;
-		}
-	}
+                        f_write(&fil_W, logBuffer[flushIndex], LOG_BUFFER_SIZE, &writtenlog); // リングバッファから書き出し
+                        freeBufCount++;                                                       // バッファ解放
+                        flushIndex = (flushIndex + 1) % LOG_BUFFER_COUNT;                     // 次のバッファへ
+                        if (flushIndex == activeIndex)                                       // 全バッファ書き込み済みなら終了
+                                sendSD = false;                                              // 書き込み要求を解除
+                }
+        }
 }
 #endif
 ////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## 概要
- LOG_BUFFER_COUNT を 8 に増加
- 未使用バッファ数を監視するカウンタを追加
- バッファ枯渇時に書き込みを一時停止する制御を実装
- 追加したバッファ制御に補足コメントを追記

## テスト
- `make` : Makefile が無いため実行不可


------
https://chatgpt.com/codex/tasks/task_e_68b31e3e236c83239d6c2586f8d7c55a