### PR TITLE
修正: readLogDistanceの曲率半径比較条件を改善

### DIFF
--- a/robotrace_v2/Core/Src/courseAnalysis.c
+++ b/robotrace_v2/Core/Src/courseAnalysis.c
@@ -178,7 +178,7 @@ int16_t readLogDistance(int logNumber)
 			}
 
 			// 一定距離ごとに処理
-			if (i % (CALCDISTANCE / 10) == 0)
+			if (i > 0 && i % (CALCDISTANCE / 10) == 0) // i==0では処理しない
 			{
 				sortROC = (int16_t *)malloc(sizeof(int16_t) * cntCurR); // 計算した曲率半径カウント分の配列を作成
 				memcpy(sortROC, ROCbuff, sizeof(int16_t) * cntCurR);	// 作成した配列に曲率半径をコピーする
@@ -199,7 +199,8 @@ int16_t readLogDistance(int logNumber)
 
 				PPAD[numD].boostSpeed = asignVelocity(PPAD[numD].ROC); // 曲率半径ごとの速度を計算する
 
-				if (PPAD[i].ROC == PPAD[i - 1].ROC)
+				// 前回の曲率半径と比較(numDが1以上の場合のみ)
+				if (numD >= 1 && PPAD[numD].ROC == PPAD[numD - 1].ROC)
 				{
 					numStraight++;
 				}


### PR DESCRIPTION
## Summary
- 距離解析でi==0を除外し、余計な処理を防止
- 曲率半径比較にnumDインデックスを使用し、前回値との比較を安全化

## Testing
- `make` *(失敗: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68b32481e5c88323a08e4f2bce520158