### PR TITLE
Handle f_readdir errors in createLog

### DIFF
--- a/robotrace_v2/Core/Src/SDcard.c
+++ b/robotrace_v2/Core/Src/SDcard.c
@@ -143,10 +143,15 @@ void createLog(void)
 
 	do
 	{
-		f_readdir(&dir, &fno);
+		fresult = f_readdir(&dir, &fno);
+		if (fresult != FR_OK)
+		{
+			// エラーが発生した場合はループを抜けてファイル探索を中断
+			break;
+		}
 		tp = strtok(fno.fname, "."); // 拡張子削除
 		if (atoi(tp) > fileNumber)
-		{						   // 番号比較
+		{                                                  // 番号比較
 			fileNumber = atoi(tp); // 文字列を数値に変換
 		}
 	} while (fno.fname[0] != 0); // ファイルの有無を確認

--- a/robotrace_v2/Core/Src/SDcard.c
+++ b/robotrace_v2/Core/Src/SDcard.c
@@ -149,12 +149,12 @@ void createLog(void)
 			// エラーが発生した場合はループを抜けてファイル探索を中断
 			break;
 		}
-		tp = strtok(fno.fname, "."); // 拡張子削除
+		tp = strtok(fno.fname, ".");	// 拡張子削除
 		if (atoi(tp) > fileNumber)
-		{                                                  // 番号比較
-			fileNumber = atoi(tp); // 文字列を数値に変換
+		{								// 番号比較
+			fileNumber = atoi(tp);		// 文字列を数値に変換
 		}
-	} while (fno.fname[0] != 0); // ファイルの有無を確認
+	} while (fno.fname[0] != 0);		// ファイルの有無を確認
 
 	f_closedir(&dir); // directory close
 


### PR DESCRIPTION
## Summary
- safeguard `createLog` against `f_readdir` errors

## Testing
- `make -n` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68b32de6728c832381b79b46bfcec3fb