### PR TITLE
Initialize accumulators before ring buffer sum

### DIFF
--- a/robotrace_v2/Core/Src/courseAnalysis.c
+++ b/robotrace_v2/Core/Src/courseAnalysis.c
@@ -503,13 +503,15 @@ int16_t calcXYcies(int logNumber)
 			yValues[i & (SHORTCUTWINDOW - 1)] = y;
 			degzValues[i & (SHORTCUTWINDOW - 1)] = degz;
 
-			// リングバッファの総和を計算
-			for (j = 0; j < SHORTCUTWINDOW; j++)
-			{
-				xm += xValues[j];
-				ym += yValues[j];
-				degzm += degzValues[j];
-			}
+                        // リングバッファの総和計算前に初期化
+                        xm = ym = degzm = 0.0f;
+                        // リングバッファの総和を計算
+                        for (j = 0; j < SHORTCUTWINDOW; j++)
+                        {
+                                xm += xValues[j];
+                                ym += yValues[j];
+                                degzm += degzValues[j];
+                        }
 
 			// 移動平均を計算(ショートカット座標)
 			xm /= SHORTCUTWINDOW;

--- a/robotrace_v2/Core/Src/courseAnalysis.c
+++ b/robotrace_v2/Core/Src/courseAnalysis.c
@@ -504,7 +504,7 @@ int16_t calcXYcies(int logNumber)
 			degzValues[i & (SHORTCUTWINDOW - 1)] = degz;
 
                         // リングバッファの総和計算前に初期化
-                        xm = ym = degzm = 0.0f;
+                        xm = ym = degzm = 0.0f; // 各周回で正しい平均値を得るためリセット
                         // リングバッファの総和を計算
                         for (j = 0; j < SHORTCUTWINDOW; j++)
                         {

--- a/robotrace_v2/Core/Src/courseAnalysis.c
+++ b/robotrace_v2/Core/Src/courseAnalysis.c
@@ -503,15 +503,15 @@ int16_t calcXYcies(int logNumber)
 			yValues[i & (SHORTCUTWINDOW - 1)] = y;
 			degzValues[i & (SHORTCUTWINDOW - 1)] = degz;
 
-                        // リングバッファの総和計算前に初期化
-                        xm = ym = degzm = 0.0f; // 各周回で正しい平均値を得るためリセット
-                        // リングバッファの総和を計算
-                        for (j = 0; j < SHORTCUTWINDOW; j++)
-                        {
-                                xm += xValues[j];
-                                ym += yValues[j];
-                                degzm += degzValues[j];
-                        }
+			// リングバッファの総和計算前に初期化
+			xm = ym = degzm = 0.0f; // 各周回で正しい平均値を得るためリセット
+			// リングバッファの総和を計算
+			for (j = 0; j < SHORTCUTWINDOW; j++)
+			{
+				xm += xValues[j];
+				ym += yValues[j];
+				degzm += degzValues[j];
+			}
 
 			// 移動平均を計算(ショートカット座標)
 			xm /= SHORTCUTWINDOW;


### PR DESCRIPTION
## Summary
- Reset `xm`, `ym`, and `degzm` before summing ring buffer entries in `calcXYcies`

## Testing
- `gcc -fsyntax-only -std=c99 -Irobotrace_v2/Core/Inc -Irobotrace_v2/Drivers/STM32F4xx_HAL_Driver/Inc -Irobotrace_v2/Drivers/CMSIS/Device/ST/STM32F4xx/Include -Irobotrace_v2/Drivers/CMSIS/Include robotrace_v2/Core/Src/courseAnalysis.c` *(fails: _ansi.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b32fed54a883239ecc0ff690351ffe