### PR TITLE
readLogDistanceにマーカー関連のコメントを追加

### DIFF
--- a/robotrace_v2/Core/Src/courseAnalysis.c
+++ b/robotrace_v2/Core/Src/courseAnalysis.c
@@ -140,6 +140,8 @@ int16_t readLogDistance(int logNumber)
 		{
 			sscanf(log, "%d,%d,%f,%d,%d,%d,", &time, &velo, &angVelo, &marker, &distance, &roc);
 			// 解析処理
+			// marker==3: 交差線マーカー
+			// marker==2: 左マーカー。直線走行中のみカーブマーカーとして扱う
 			if (marker == 3 || (marker == 2 && straightState))
 			{
 				// カーブマーカーを通過したときにマーカー位置を記録
@@ -148,6 +150,7 @@ int16_t readLogDistance(int logNumber)
 
 				if (marker == 2 && straightState)
 				{
+				// 直線後の左マーカー検出でフラグと距離をリセット
 					straightState = false;
 					straightMeter = 0;
 				}
@@ -210,6 +213,8 @@ int16_t readLogDistance(int logNumber)
 				straightMeter = 0;
 			}
 
+			// 直線区間が100mm以上続いたら直線走行中と判定し、
+			// 次に検出する左マーカーをカーブ開始とするためのフラグを立てる
 			if (straightMeter >= 100)
 			{
 				straightState = true;


### PR DESCRIPTION
## Summary
- readLogDistanceでcrossline(3)と左マーカー(2)の意味をコメントで説明
- 左マーカー検出後にフラグと距離をリセットする処理にコメントを追加
- 直線区間100mm継続でフラグを立てる理由をコメントで補足

## Testing
- `gcc -fsyntax-only -ICore/Inc -IDrivers/STM32F4xx_HAL_Driver/Inc -IDrivers/CMSIS/Device/ST/STM32F4xx/Include -IDrivers/CMSIS/Include Core/Src/courseAnalysis.c` *(エラー: STM32F4xxデバイス未選択や型未定義)*

------
https://chatgpt.com/codex/tasks/task_e_68b3364468748323810348920eac273e