### PR TITLE
fix: setLogStrのバッファ型を修正

### DIFF
--- a/robotrace_v2/Core/Src/SDcard.c
+++ b/robotrace_v2/Core/Src/SDcard.c
@@ -565,7 +565,8 @@ void getFileNumbers(void)
 /////////////////////////////////////////////////////////////////////
 void setLogStr(uint8_t *column, uint8_t *format)
 {
-	uint8_t *columnStr[30], formatStr[30];
+	uint8_t columnStr[30];	// ヘッダー文字列を一時的に格納するバッファ
+	uint8_t formatStr[30];	// フォーマット文字列を一時的に格納するバッファ
 
 	// copy str to local variable
 	strcpy(columnStr, column);


### PR DESCRIPTION
## Summary
- setLogStrのローカルバッファをuint8_t配列に変更しコメントを追加

## Testing
- `make test` (fails: No rule to make target 'test')
- `make` (fails: No targets specified and no makefile found)


------
https://chatgpt.com/codex/tasks/task_e_68b33f7d24d48323a80acd7526d6c42c