### PR TITLE
Handle empty filenames in SD log creation

### DIFF
--- a/robotrace_v2/Core/Src/SDcard.c
+++ b/robotrace_v2/Core/Src/SDcard.c
@@ -149,8 +149,13 @@ void createLog(void)
 			// エラーが発生した場合はループを抜けてファイル探索を中断
 			break;
 		}
+		if (fno.fname[0] == 0)
+		{
+			// ファイル名が空の場合はループを終了
+			break;
+		}
 		tp = strtok(fno.fname, ".");	// 拡張子削除
-		if (atoi(tp) > fileNumber)
+		if (tp != NULL && atoi(tp) > fileNumber)
 		{								// 番号比較
 			fileNumber = atoi(tp);		// 文字列を数値に変換
 		}


### PR DESCRIPTION
## Summary
- break out of log creation loop when f_readdir returns an empty filename
- safeguard strtok/atoi so they run only for non-empty filenames

## Testing
- `gcc -fsyntax-only -ICore/Inc -IFATFS/App -IDrivers/STM32F4xx_HAL_Driver/Inc -IDrivers/STM32F4xx_HAL_Driver/Inc/Legacy -IMiddlewares/Third_Party/FatFs/src -IDrivers/CMSIS/Device/ST/STM32F4xx/Include -IDrivers/CMSIS/Include Core/Src/SDcard.c` *(fails: fatal error: _ansi.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b33f5f69e4832384fb9c7981c5a96d