### PR TITLE
SDtestでSPI待ちタイムアウトを追加

### DIFF
--- a/robotrace_v2/Core/Src/SDcard.c
+++ b/robotrace_v2/Core/Src/SDcard.c
@@ -589,8 +589,14 @@ void SDtest(void)
 	FRESULT fresult;
 
 	fresult = f_open(&fil_T, "test.csv", FA_OPEN_ALWAYS | FA_WRITE); // create file
+	uint32_t start = HAL_GetTick(); // SPI待ちにタイムアウトを設定
 	while (HAL_SPI_GetState(&hspi3) != HAL_SPI_STATE_READY)
-		;
+	{
+		if (HAL_GetTick() - start > SPI_TIMEOUT)
+		{
+			break;
+		}
+	}
 	f_close(&fil_T);
 }
 /////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Summary
- SDtest関数にSPI待ちのタイムアウト処理を追加

## Testing
- `make` *(missing Makefile)*

------
https://chatgpt.com/codex/tasks/task_e_68b3ac84942883239b1bd05a7284adca