### PR TITLE
fix: correct f_read pointer usage in endLog

### DIFF
--- a/robotrace_v2/Core/Src/SDcard.c
+++ b/robotrace_v2/Core/Src/SDcard.c
@@ -475,7 +475,7 @@ void endLog(void)
 	clearXYcie(); // xy座標クリア
 	for (j = 0; j < cntSend; j++)
 	{
-		f_read(&fil, log, sizeof(log), readByte);
+		f_read(&fil, log, sizeof(log), &readByte); // 読み込んだバイト数を取得するためポインタを渡す
 		logaddress = log; // 読み込んだ配列の先頭アドレスを取得
 
 		// 型ごとに変数を復元


### PR DESCRIPTION
## Summary
- pass `readByte` by pointer to `f_read` in `endLog`
- document why the argument is a pointer

## Testing
- `gcc -c Core/Src/SDcard.c -ICore/Inc -IMiddlewares/Third_Party/FatFs/src -IDrivers/STM32F4xx_HAL_Driver/Inc -IDrivers/CMSIS/Device/ST/STM32F4xx/Include -IDrivers/CMSIS/Include 2>&1 | head -n 20` *(fails: Please select first the target STM32F4xx device)*

------
https://chatgpt.com/codex/tasks/task_e_68b3b3c274708323806d3212ec4e360d