### PR TITLE
createLogのf_open失敗時の処理を追加

### DIFF
--- a/robotrace_v2/Core/Src/SDcard.c
+++ b/robotrace_v2/Core/Src/SDcard.c
@@ -176,6 +176,11 @@ void createLog(void)
 	sprintf(fileName, "%d", fileNumber);						   // 数値を文字列に変換
 	strcat(fileName, ".csv");									   // 拡張子を追加
 	fresult = f_open(&fil_W, fileName, FA_OPEN_ALWAYS | FA_WRITE); // create file
+	if (fresult != FR_OK)
+	{
+		// ファイルオープンに失敗した場合はログ作成を中止する
+		return; // エラーが発生したため処理を終了
+	}
 
 	strcpy(columnTitle, "");
 	strcpy(formatLog, "");


### PR DESCRIPTION
## Summary
- f_open失敗時にログ作成を中止する際、printfを使わずコメントで挙動を明示

## Testing
- `gcc -c Core/Src/SDcard.c -ICore/Inc -IFATFS/App -IFATFS/Target -IMiddlewares/Third_Party/FatFs/src -IDrivers/STM32F4xx_HAL_Driver/Inc -IDrivers/CMSIS/Device/ST/STM32F4xx/Include -IDrivers/CMSIS/Include` *(fails: unknown type name `uint32_t`)*

------
https://chatgpt.com/codex/tasks/task_e_68b3b3beaa688323907233d86c46082b