### PR TITLE
feat: add sensor test init helper

### DIFF
--- a/robotrace_v2/Core/Src/setup.c
+++ b/robotrace_v2/Core/Src/setup.c
@@ -70,6 +70,7 @@ static void test_switch(void); // タクトスイッチ
 static void test_battery(void); // バッテリ電圧
 static void test_linesensor(void); // ラインセンサ
 static void test_rgbled(void); // RGBLED
+static void init_sensor_test(const char* title, Font font, uint8_t x); // 表示初期化
 
 typedef void (*SensorTestFunc)(void);
 typedef struct
@@ -235,14 +236,29 @@ static void setup_speed_param(void)
 		}
 		case 18: // 2次走行_ショートカット
 		{
-			dataTuningUDF(&tgtParam.shortCut, 0.1, 0.0, 10.0);
-			ssd1306_SetCursor(0, 24);
-			ssd1306_printf(Font_6x8, "BST shortCut:%3gm/s", tgtParam.shortCut);
-			break;
-		}
-	}
+        dataTuningUDF(&tgtParam.shortCut, 0.1, 0.0, 10.0);
+        ssd1306_SetCursor(0, 24);
+        ssd1306_printf(Font_6x8, "BST shortCut:%3gm/s", tgtParam.shortCut);
+        break;
+                }
+        }
 
     beforePparam = pattern.parameter1; // 選択項目を記録
+}
+
+///////////////////////////////////////////////////////////////////////////////////////
+// モジュール名 init_sensor_test
+// 処理概要     センサテスト画面の初期化
+// 引数         title : 表示文字列
+//              font  : 使用フォント
+//              x     : タイトル表示位置
+// 戻り値       なし
+///////////////////////////////////////////////////////////////////////////////////////
+static void init_sensor_test(const char* title, Font font, uint8_t x)
+{
+	ssd1306_FillRectangle(0, 16, 127, 63, Black); // 表示領域をクリア
+	ssd1306_SetCursor(x, 16); // タイトルの位置設定
+	ssd1306_printf(font, title); // タイトルを描画
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////
@@ -256,9 +272,7 @@ static void test_motor(void)
 	if (pattern.sensors != pattern.beforeSensors)
 	{
 		// 切替時に実行
-		ssd1306_FillRectangle(0, 16, 127, 63, Black); // 黒塗り
-		ssd1306_SetCursor(47, 16);
-		ssd1306_printf(Font_6x8, "Motor");
+		init_sensor_test("Motor", Font_6x8, 47); // 画面クリアとタイトル表示
 		motor_test = 0;
 	}
 	// Duty表示
@@ -312,9 +326,7 @@ static void test_imu_deg(void)
 	if (pattern.sensors != pattern.beforeSensors)
 	{
 		// 切替時に実行
-		ssd1306_FillRectangle(0, 16, 127, 63, Black); // 黒塗り
-		ssd1306_SetCursor(36, 16);
-		ssd1306_printf(Font_7x10, "IMU[deg]");
+		init_sensor_test("IMU[deg]", Font_7x10, 36); // 画面クリアとタイトル表示
 		motor_test = 1;
 	}
 
@@ -360,9 +372,7 @@ static void test_imu_accel(void)
 	if (pattern.sensors != pattern.beforeSensors)
 	{
 		// 切替時に実行
-		ssd1306_FillRectangle(0, 16, 127, 63, Black); // 黒塗り
-		ssd1306_SetCursor(36, 16);
-		ssd1306_printf(Font_7x10, "IMU[g]");
+		init_sensor_test("IMU[g]", Font_7x10, 36); // 画面クリアとタイトル表示
 	}
 
 	ssd1306_SetCursor(0, 30);
@@ -387,9 +397,7 @@ static void test_marker(void)
 	if (pattern.sensors != pattern.beforeSensors)
 	{
 		// 切替時に実行
-		ssd1306_FillRectangle(0, 16, 127, 63, Black); // 黒塗り
-		ssd1306_SetCursor(15, 16);
-		ssd1306_printf(Font_7x10, "Marker sensors");
+		init_sensor_test("Marker sensors", Font_7x10, 15); // 画面クリアとタイトル表示
 	}
 	ssd1306_SetCursor(0, 30);
 	ssd1306_printf(Font_7x10, "sensors:%d", getMarkerSensor());
@@ -418,9 +426,7 @@ static void test_switch(void)
 	if (pattern.sensors != pattern.beforeSensors)
 	{
 		// 切替時に実行
-		ssd1306_FillRectangle(0, 16, 127, 63, Black); // 黒塗り
-		ssd1306_SetCursor(32, 16);
-		ssd1306_printf(Font_7x10, "Switches");
+		init_sensor_test("Switches", Font_7x10, 32); // 画面クリアとタイトル表示
 	}
 	ssd1306_SetCursor(0, 30);
 	ssd1306_printf(Font_7x10, "Board SW:%d", swValMainTact);
@@ -440,9 +446,7 @@ static void test_battery(void)
 	if (pattern.sensors != pattern.beforeSensors)
 	{
 		// 切替時に実行
-		ssd1306_FillRectangle(0, 16, 127, 63, Black); // 黒塗り
-		ssd1306_SetCursor(32, 16);
-		ssd1306_printf(Font_7x10, "Battery");
+		init_sensor_test("Battery", Font_7x10, 32); // 画面クリアとタイトル表示
 	}
 	ssd1306_SetCursor(0, 30);
 	ssd1306_printf(Font_7x10, "batteryADAD:%d", batteryAD);
@@ -462,7 +466,7 @@ static void test_linesensor(void)
 	if (pattern.sensors != pattern.beforeSensors)
 	{
 		// 切替時に実行
-		ssd1306_FillRectangle(0, 16, 127, 63, Black); // 黒塗り
+		init_sensor_test("", Font_6x8, 0); // 画面クリア
 		// センサ基板形状
 		ssd1306_DrawArc(64, 81, 66, 90, 270, White);
 		ssd1306_DrawArc(64, 81, 35, 90, 270, White);
@@ -542,9 +546,7 @@ static void test_rgbled(void)
 	if (pattern.sensors != pattern.beforeSensors)
 	{
 		// 切替時に実行
-		ssd1306_FillRectangle(0, 16, 127, 63, Black); // 黒塗り
-		ssd1306_SetCursor(43, 16);
-		ssd1306_printf(Font_7x10, "RGBLED");
+		init_sensor_test("RGBLED", Font_7x10, 43); // 画面クリアとタイトル表示
 	}
 
 	data_select(&motor_test, SW_PUSH);

--- a/robotrace_v2/Core/Src/setup.c
+++ b/robotrace_v2/Core/Src/setup.c
@@ -70,7 +70,7 @@ static void test_switch(void); // タクトスイッチ
 static void test_battery(void); // バッテリ電圧
 static void test_linesensor(void); // ラインセンサ
 static void test_rgbled(void); // RGBLED
-static void init_sensor_test(const char* title, Font font, uint8_t x); // 表示初期化
+static void init_sensor_test(const char* title, FontDef font, uint8_t x); // 表示初期化
 
 typedef void (*SensorTestFunc)(void);
 typedef struct
@@ -236,12 +236,12 @@ static void setup_speed_param(void)
 		}
 		case 18: // 2次走行_ショートカット
 		{
-        dataTuningUDF(&tgtParam.shortCut, 0.1, 0.0, 10.0);
-        ssd1306_SetCursor(0, 24);
-        ssd1306_printf(Font_6x8, "BST shortCut:%3gm/s", tgtParam.shortCut);
-        break;
-                }
+			dataTuningUDF(&tgtParam.shortCut, 0.1, 0.0, 10.0);
+			ssd1306_SetCursor(0, 24);
+			ssd1306_printf(Font_6x8, "BST shortCut:%3gm/s", tgtParam.shortCut);
+			break;
         }
+    }
 
     beforePparam = pattern.parameter1; // 選択項目を記録
 }
@@ -254,7 +254,7 @@ static void setup_speed_param(void)
 //              x     : タイトル表示位置
 // 戻り値       なし
 ///////////////////////////////////////////////////////////////////////////////////////
-static void init_sensor_test(const char* title, Font font, uint8_t x)
+static void init_sensor_test(const char* title, FontDef font, uint8_t x)
 {
 	ssd1306_FillRectangle(0, 16, 127, 63, Black); // 表示領域をクリア
 	ssd1306_SetCursor(x, 16); // タイトルの位置設定


### PR DESCRIPTION
## Summary
- add `init_sensor_test` helper to clear screen and show title
- refactor sensor test functions to use the helper
- align indentation with existing tab style

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3c0d5ca688323b19c22ef4e12282d