### PR TITLE
Add timeout safety check for SD log buffer

### DIFF
--- a/robotrace_v2/Core/Src/SDcard.c
+++ b/robotrace_v2/Core/Src/SDcard.c
@@ -314,11 +314,20 @@ void writeLogBufferPuts(uint8_t c, uint8_t s, uint8_t i, uint8_t f, ...)
 					break;
 				}
 			}
-			logBuffIndex = 0;									// 書込位置をリセット
-			activeIndex = (activeIndex + 1) % LOG_BUFFER_COUNT; // リングバッファ切替
-			activeBuf = logBuffer[activeIndex];					// アクティブバッファ更新
-			freeBufCount--;										// 使用バッファを減算
-			sendSD = true;										// SD書き込みを要求
+			// タイムアウト後に空きバッファ数を確認
+			if (freeBufCount == 0)
+			{
+				// タイムアウト後も空きバッファがない場合はアンダーフロー防止のためエラー扱い
+				logOverflow = true; // バッファ不足エラーフラグ
+			}
+			else
+			{
+				// 空きバッファが確保できた場合のみリングバッファを進める
+				logBuffIndex = 0;									// 書込位置をリセット
+				activeIndex = (activeIndex + 1) % LOG_BUFFER_COUNT; // リングバッファ切替
+				activeBuf = logBuffer[activeIndex];					// アクティブバッファ更新
+				freeBufCount--;										// 使用バッファを減算
+				sendSD = true;										// SD書き込みを要求
 		}
 	}
 }
@@ -347,7 +356,7 @@ void writeLogPuts(void)
 				sendSD = false;
 				return;
 			}
-			freeBufCount++;															// バッファ解放
+				freeBufCount++;															// バッファ解放
 			flushIndex = (flushIndex + 1) % LOG_BUFFER_COUNT;						// 次のバッファへ
 			if (flushIndex == activeIndex)											// 全バッファ書き込み済みなら終了
 				sendSD = false;														// 書き込み要求を解除

--- a/robotrace_v2/Core/Src/SDcard.c
+++ b/robotrace_v2/Core/Src/SDcard.c
@@ -328,6 +328,7 @@ void writeLogBufferPuts(uint8_t c, uint8_t s, uint8_t i, uint8_t f, ...)
 				activeBuf = logBuffer[activeIndex];					// アクティブバッファ更新
 				freeBufCount--;										// 使用バッファを減算
 				sendSD = true;										// SD書き込みを要求
+			}
 		}
 	}
 }
@@ -356,7 +357,7 @@ void writeLogPuts(void)
 				sendSD = false;
 				return;
 			}
-				freeBufCount++;															// バッファ解放
+			freeBufCount++;															// バッファ解放
 			flushIndex = (flushIndex + 1) % LOG_BUFFER_COUNT;						// 次のバッファへ
 			if (flushIndex == activeIndex)											// 全バッファ書き込み済みなら終了
 				sendSD = false;														// 書き込み要求を解除


### PR DESCRIPTION
## Summary
- avoid decrementing log buffer count when timeout occurs
- flag buffer shortage error instead of allowing underflow
- document timeout buffer check and normal transition

## Testing
- `gcc /tmp/test_sdcard.c -o /tmp/test_sdcard && /tmp/test_sdcard`


------
https://chatgpt.com/codex/tasks/task_e_68b3c0df86f0832382f5fc3349ffe4be