### PR TITLE
Add short HAL_Delay for log buffer wait

### DIFF
--- a/robotrace_v2/Core/Src/SDcard.c
+++ b/robotrace_v2/Core/Src/SDcard.c
@@ -306,14 +306,14 @@ void writeLogBufferPuts(uint8_t c, uint8_t s, uint8_t i, uint8_t f, ...)
 		{
 			// バッファが枯渇している場合は空きができるまで待機
 			uint32_t startTick = HAL_GetTick(); // タイムアウト計測開始
-                        while (freeBufCount == 0)
-                        {
-                                HAL_Delay(1); // 空きバッファ解放待ちでCPU負荷を抑えるため短時間待機
-                                if (HAL_GetTick() - startTick > 1000) // 一定時間待機しても空きがない場合はタイムアウト
-                                {
-                                        break;
-                                }
-                        }
+			while (freeBufCount == 0)
+			{
+				HAL_Delay(1); // 空きバッファ解放待ちでCPU負荷を抑えるため短時間待機
+				if (HAL_GetTick() - startTick > 1000) // 一定時間待機しても空きがない場合はタイムアウト
+				{
+					break;
+				}
+			}
 			logBuffIndex = 0;									// 書込位置をリセット
 			activeIndex = (activeIndex + 1) % LOG_BUFFER_COUNT; // リングバッファ切替
 			activeBuf = logBuffer[activeIndex];					// アクティブバッファ更新

--- a/robotrace_v2/Core/Src/SDcard.c
+++ b/robotrace_v2/Core/Src/SDcard.c
@@ -306,14 +306,14 @@ void writeLogBufferPuts(uint8_t c, uint8_t s, uint8_t i, uint8_t f, ...)
 		{
 			// バッファが枯渇している場合は空きができるまで待機
 			uint32_t startTick = HAL_GetTick(); // タイムアウト計測開始
-			while (freeBufCount == 0)
-			{
-				// 空きバッファの解放を待機（HAL_Delayは全処理を停止するため使用しない）
-				if (HAL_GetTick() - startTick > 1000) // 一定時間待機しても空きがない場合はタイムアウト
-				{
-					break;
-				}
-			}
+                        while (freeBufCount == 0)
+                        {
+                                HAL_Delay(1); // 空きバッファ解放待ちでCPU負荷を抑えるため短時間待機
+                                if (HAL_GetTick() - startTick > 1000) // 一定時間待機しても空きがない場合はタイムアウト
+                                {
+                                        break;
+                                }
+                        }
 			logBuffIndex = 0;									// 書込位置をリセット
 			activeIndex = (activeIndex + 1) % LOG_BUFFER_COUNT; // リングバッファ切替
 			activeBuf = logBuffer[activeIndex];					// アクティブバッファ更新


### PR DESCRIPTION
## Summary
- wait for free log buffer with HAL_Delay to reduce CPU load

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3c194da408323922805734a2157e4