### PR TITLE
Handle f_getfree failure in SD card init

### DIFF
--- a/robotrace_v2/Core/Src/SDcard.c
+++ b/robotrace_v2/Core/Src/SDcard.c
@@ -102,7 +102,14 @@ bool initMicroSD(void)
 		printf("SD CARD mounted successfully...\r\n");
 
 		// 空き容量を計算
-		f_getfree("", &fre_clust, &pfs);							// cluster size
+		fresult = f_getfree("", &fre_clust, &pfs);							// cluster size
+		if (fresult != FR_OK)
+		{
+			// 空き容量取得に失敗した場合はエラーメッセージを出力して終了
+			initMSD = false;
+			printf("error in getting SD CARD free space...\r\n");
+			return false;
+		}
 		total = (uint32_t)((pfs->n_fatent - 2) * pfs->csize * 0.5); // total capacity
 		printf("SD_SIZE: \t%lu\r\n", total);
 		free_space = (uint32_t)(fre_clust * pfs->csize * 0.5); // empty capacity


### PR DESCRIPTION
## Summary
- detect and report errors when retrieving SD card free space during initialization
- return failure and log message if `f_getfree` does not succeed

## Testing
- `gcc -fsyntax-only robotrace_v2/Core/Src/SDcard.c -Irobotrace_v2/Core/Inc -Irobotrace_v2/FATFS/App -Irobotrace_v2/Drivers/CMSIS/Include -Irobotrace_v2/Drivers/CMSIS/Device/ST/STM32F4xx/Include -Irobotrace_v2/Drivers/STM32F4xx_HAL_Driver/Inc '-DHAL_GPIO_ReadPin(x,y)=0' -std=c99 -include stdint.h` *(fails: Please select first the target STM32F4xx device used in your application)*
- `gcc /tmp/testbuild/test_init.c -o /tmp/testbuild/test_init && /tmp/testbuild/test_init`

------
https://chatgpt.com/codex/tasks/task_e_68b3d10e98cc832398984c514b845d08