### PR TITLE
Handle f_opendir error in SD log creation

### DIFF
--- a/robotrace_v2/Core/Src/SDcard.c
+++ b/robotrace_v2/Core/Src/SDcard.c
@@ -138,9 +138,15 @@ void createLog(void)
 	uint8_t *tp, fileName[10];
 	uint16_t fileNumber = 0;
 
-	f_opendir(&dir, "/"); // directory open
+        fresult = f_opendir(&dir, "/"); // directory open
+        if (fresult != FR_OK)
+        {
+                printf("failed to open root directory: %d\r\n", fresult);
+                // SDカードが未接続などでディレクトリを開けないため、ログ作成を中断する
+                return;
+        }
 
-	do
+        do
 	{
 		fresult = f_readdir(&dir, &fno);
 		if (fresult != FR_OK)

--- a/robotrace_v2/Core/Src/SDcard.c
+++ b/robotrace_v2/Core/Src/SDcard.c
@@ -138,15 +138,15 @@ void createLog(void)
 	uint8_t *tp, fileName[10];
 	uint16_t fileNumber = 0;
 
-        fresult = f_opendir(&dir, "/"); // directory open
-        if (fresult != FR_OK)
-        {
-                printf("failed to open root directory: %d\r\n", fresult);
-                // SDカードが未接続などでディレクトリを開けないため、ログ作成を中断する
-                return;
-        }
+	fresult = f_opendir(&dir, "/"); // directory open
+	if (fresult != FR_OK)
+{
+		printf("failed to open root directory: %d\r\n", fresult);
+		// SDカードが未接続などでディレクトリを開けないため、ログ作成を中断する
+		return;
+	}
 
-        do
+	do
 	{
 		fresult = f_readdir(&dir, &fno);
 		if (fresult != FR_OK)


### PR DESCRIPTION
## Summary
- check `f_opendir` result in `createLog`
- abort log creation and print message when directory can't be opened

## Testing
- `gcc -c robotrace_v2/Core/Src/SDcard.c -Irobotrace_v2/Core/Inc -Irobotrace_v2/Middlewares/Third_Party/FatFs/src -Irobotrace_v2/Drivers/STM32F4xx_HAL_Driver/Inc -Irobotrace_v2/Drivers/CMSIS/Device/ST/STM32F4xx/Include -Irobotrace_v2/Drivers/CMSIS/Include -DSTM32F446xx` *(fails: _ansi.h missing)*
- `gcc /tmp/test_createLog.c -o /tmp/test_createLog && /tmp/test_createLog`

------
https://chatgpt.com/codex/tasks/task_e_68b3d11057c88323ba989f3e2f26d55d