### PR TITLE
Handle f_readdir errors in getFileNumbers

### DIFF
--- a/robotrace_v2/Core/Inc/SDcard.h
+++ b/robotrace_v2/Core/Inc/SDcard.h
@@ -34,6 +34,7 @@ extern int32_t encLog;
 extern volatile uint8_t freeBufCount; // 未使用バッファ数を監視
 extern bool logOverflow;     // ログバッファ上限超過フラグ
 extern bool markerOverflow;  // マーカーバッファ上限超過フラグ
+extern bool getFileNumbersError; // getFileNumbersでエラーが発生した際のフラグ
 //====================================//
 // プロトタイプ宣言
 //====================================//

--- a/robotrace_v2/Core/Src/SDcard.c
+++ b/robotrace_v2/Core/Src/SDcard.c
@@ -62,6 +62,7 @@ int16_t endFileIndex = 0; // ログの最終番号
 // カウンタ
 uint8_t cntLog = 0;
 int32_t encLog = 0;
+bool getFileNumbersError = false; // getFileNumbersでエラーが発生した際のフラグ
 
 /////////////////////////////////////////////////////////////////////
 // モジュール名 insertSD
@@ -582,11 +583,18 @@ void getFileNumbers(void)
 	{
 		do
 		{
-			f_readdir(&dir, &fno);
+			fresult = f_readdir(&dir, &fno);
+			if (fresult != FR_OK)
+			{
+				// ディレクトリ読み込みに失敗した場合はループを抜けてフラグを設定
+				getFileNumbersError = true;
+				printf("f_readdir error: %d\r\n", fresult); // エラー内容を出力
+				break;
+			}
 			if (strstr(fno.fname, ".csv") != NULL)
 			{
 				// csvファイルのとき
-				tp = strtok(fno.fname, ".");		  // 拡張子削除
+				tp = strtok(fno.fname, ".");              // 拡張子削除
 				fileNumbers[endFileIndex] = atoi(tp); // 文字列を数値に変換
 				endFileIndex++;
 			}


### PR DESCRIPTION
## Summary
- `getFileNumbers` 関数で `f_readdir` の戻り値を確認し、エラー時に処理を中断
- エラー検出時にフラグを設定し、ログ出力を追加

## Testing
- `gcc /tmp/test_getFileNumbers.c -o /tmp/test_getFileNumbers`
- `/tmp/test_getFileNumbers`


------
https://chatgpt.com/codex/tasks/task_e_68b3d113aa00832388c4b12b4d9ac10d