### PR TITLE
writeLogBufferPutsのva_arg型をunsigned intに変更

### DIFF
--- a/robotrace_v2/Core/Src/SDcard.c
+++ b/robotrace_v2/Core/Src/SDcard.c
@@ -306,19 +306,23 @@ void writeLogBufferPuts(uint8_t c, uint8_t s, uint8_t i, uint8_t f, ...)
 	if (modeLOG)
 	{
 		// 	バッファ配列に保存
-		va_start(args, f);
-		// logBuffer[0] = va_arg( args, uint8_t* );
-		for (cnt = 0; cnt < c; cnt++)
-			send8bit(va_arg(args, uint32_t));
-		for (cnt = 0; cnt < s; cnt++)
-			send16bit(va_arg(args, uint32_t));
-		for (cnt = 0; cnt < i; cnt++)
-			send32bit(va_arg(args, uint32_t));
-		for (cnt = 0; cnt < f; cnt++)
-		{
-			ftoi.f = va_arg(args, double); // 共用体を使用してfloat型のビット操作をできるようにする
-			send32bit(ftoi.i);
-		}
+                va_start(args, f);
+                // logBuffer[0] = va_arg( args, uint8_t* );
+                // 8bitデータをバッファへ送る
+                for (cnt = 0; cnt < c; cnt++)
+                        send8bit(va_arg(args, unsigned int)); // 可変長引数の型昇格に合わせる
+                // 16bitデータをバッファへ送る
+                for (cnt = 0; cnt < s; cnt++)
+                        send16bit(va_arg(args, unsigned int)); // 可変長引数の型昇格に合わせる
+                // 32bitデータをバッファへ送る
+                for (cnt = 0; cnt < i; cnt++)
+                        send32bit(va_arg(args, uint32_t));
+                // floatデータをバッファへ送る
+                for (cnt = 0; cnt < f; cnt++)
+                {
+                        ftoi.f = va_arg(args, double); // 共用体を使用してfloat型のビット操作をできるようにする
+                        send32bit(ftoi.i);
+                }
 		va_end(args);
 		cntSend++; // 書き込み回数をカウント
 

--- a/robotrace_v2/Core/Src/SDcard.c
+++ b/robotrace_v2/Core/Src/SDcard.c
@@ -306,23 +306,23 @@ void writeLogBufferPuts(uint8_t c, uint8_t s, uint8_t i, uint8_t f, ...)
 	if (modeLOG)
 	{
 		// 	バッファ配列に保存
-                va_start(args, f);
-                // logBuffer[0] = va_arg( args, uint8_t* );
-                // 8bitデータをバッファへ送る
-                for (cnt = 0; cnt < c; cnt++)
-                        send8bit(va_arg(args, unsigned int)); // 可変長引数の型昇格に合わせる
-                // 16bitデータをバッファへ送る
-                for (cnt = 0; cnt < s; cnt++)
-                        send16bit(va_arg(args, unsigned int)); // 可変長引数の型昇格に合わせる
-                // 32bitデータをバッファへ送る
-                for (cnt = 0; cnt < i; cnt++)
-                        send32bit(va_arg(args, uint32_t));
-                // floatデータをバッファへ送る
-                for (cnt = 0; cnt < f; cnt++)
-                {
-                        ftoi.f = va_arg(args, double); // 共用体を使用してfloat型のビット操作をできるようにする
-                        send32bit(ftoi.i);
-                }
+		va_start(args, f);
+		// logBuffer[0] = va_arg( args, uint8_t* );
+		// 8bitデータをバッファへ送る
+		for (cnt = 0; cnt < c; cnt++)
+			send8bit(va_arg(args, unsigned int)); // 可変長引数の型昇格に合わせる
+		// 16bitデータをバッファへ送る
+		for (cnt = 0; cnt < s; cnt++)
+			send16bit(va_arg(args, unsigned int)); // 可変長引数の型昇格に合わせる
+		// 32bitデータをバッファへ送る
+		for (cnt = 0; cnt < i; cnt++)
+			send32bit(va_arg(args, uint32_t));
+		// floatデータをバッファへ送る
+		for (cnt = 0; cnt < f; cnt++)
+		{
+			ftoi.f = va_arg(args, double); // 共用体を使用してfloat型のビット操作をできるようにする
+			send32bit(ftoi.i);
+		}
 		va_end(args);
 		cntSend++; // 書き込み回数をカウント
 


### PR DESCRIPTION
## Summary
- writeLogBufferPutsの8bit/16bit引数取得型をunsigned intへ変更
- 各データ送信処理にコメントを追加

## Testing
- `gcc -fsyntax-only robotrace_v2/Core/Src/SDcard.c -I robotrace_v2/Core/Inc -I robotrace_v2/Drivers/STM32F4xx_HAL_Driver/Inc -I robotrace_v2/Drivers/CMSIS/Device/ST/STM32F4xx/Include -I robotrace_v2/Drivers/CMSIS/Include -DSTM32F446xx`

------
https://chatgpt.com/codex/tasks/task_e_68b3e3fbf5fc83238ae0988f26df1427