### PR TITLE
Handle log buffer timeout when free buffer unavailable

### DIFF
--- a/robotrace_v2/Core/Src/SDcard.c
+++ b/robotrace_v2/Core/Src/SDcard.c
@@ -344,6 +344,8 @@ void writeLogBufferPuts(uint8_t c, uint8_t s, uint8_t i, uint8_t f, ...)
 			{
 				// タイムアウト後も空きバッファがない場合はアンダーフロー防止のためエラー扱い
 				logOverflow = true; // バッファ不足エラーフラグ
+				logBuffIndex = 0; // タイムアウト時は書き込みを中止
+				return; // タイムアウト時は書き込みを中止
 			}
 			else
 			{


### PR DESCRIPTION
## Summary
- return early when log buffer timeout occurs to avoid further writes
- reset logBuffIndex on timeout to maintain buffer integrity

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3ea0d195c83238ac8ae854ac52ef6