### PR TITLE
writeLogPutsで書き込みサイズ検証を追加

### DIFF
--- a/robotrace_v2/Core/Src/SDcard.c
+++ b/robotrace_v2/Core/Src/SDcard.c
@@ -384,6 +384,12 @@ void writeLogPuts(void)
 				sendSD = false;
 				return;
 			}
+			// 実際の書き込みサイズを検証
+			if (writtenlog != LOG_BUFFER_SIZE)
+			{
+				sendSD = false;
+				return;
+			}
 			freeBufCount++;															// バッファ解放
 			flushIndex = (flushIndex + 1) % LOG_BUFFER_COUNT;						// 次のバッファへ
 			if (flushIndex == activeIndex)											// 全バッファ書き込み済みなら終了


### PR DESCRIPTION
## 概要
- writeLogPutsで書き込みサイズを検証し、異常時にエラー処理を実行する分岐を追加

## テスト
- `make` (Makefileが存在せず失敗)

------
https://chatgpt.com/codex/tasks/task_e_68b3eb62b1208323a1c7b060a033f5f6