### PR TITLE
sendSD を volatile 指定し割込み共有コメントを追加

### DIFF
--- a/robotrace_v2/Core/Src/SDcard.c
+++ b/robotrace_v2/Core/Src/SDcard.c
@@ -25,7 +25,8 @@ uint8_t *activeBuf = logBuffer[0]; // 書き込み中のバッファ
 uint8_t activeIndex = 0;          // 現在のバッファ番号
 uint8_t flushIndex = 0;           // SD書き込み待ちバッファ番号
 int16_t logBuffIndex = 0;          // 一時記録バッファ書込アドレス
-bool sendSD = false;               // SD書き込み要求フラグ
+volatile bool sendSD = false;      // SD書き込み要求フラグ
+                                   // 割込みとの共有のため volatile 指定
 uint16_t cntSend = 0;
 uint8_t *logaddress;
 volatile uint8_t freeBufCount = LOG_BUFFER_COUNT - 1; // 未使用バッファ数を管理


### PR DESCRIPTION
## Summary
- SDカード書き込み要求フラグ `sendSD` を `volatile` に変更
- 割込みとの共有で `volatile` が必要である旨のコメントを追加

## Testing
- `make` *(no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3fb0987948323b278bb2e98cb4544