### PR TITLE
refactor: defer log writes outside interrupt

### DIFF
--- a/robotrace_v2/Core/Inc/timer.h
+++ b/robotrace_v2/Core/Inc/timer.h
@@ -19,5 +19,6 @@ extern float bootTime;
 void Interrupt1ms(void);
 void Interrupt100us(void);
 void Interrupt300ns(void);
+void logWriteTask(void);
 
 #endif // TIMER_H_

--- a/robotrace_v2/Core/Src/control.c
+++ b/robotrace_v2/Core/Src/control.c
@@ -258,8 +258,12 @@ void initSystem(void)
 ///////////////////////////////////////////////////////////////////////////
 void loopSystem(void)
 {
+	if (patternTrace > 10 && patternTrace < 100)        // 走行中のみ処理
+	{
+		logWriteTask();        // 割り込み外でSD書き込みを実行する
+	}
 
-	// 緊急停止処理
+        // 緊急停止処理
 	if (patternTrace > 10 && patternTrace < 100 && emcStop > 0)
 	{
 		goalTime = cntRun;

--- a/robotrace_v2/Core/Src/timer.c
+++ b/robotrace_v2/Core/Src/timer.c
@@ -8,6 +8,7 @@
 int32_t cnt5 = 0;
 int32_t cnt10 = 0;
 float bootTime;
+static volatile bool logWriteReq = false;
 /////////////////////////////////////////////////////////////////////
 // モジュール名 Interrupt1ms
 // 処理概要     タイマー割り込み(1ms)
@@ -255,7 +256,23 @@ void Interrupt1ms(void)
 void Interrupt100us(void)
 {
 #ifdef LOG_RUNNING_WRITE
-	writeLogPuts();
+        logWriteReq = true;
+#endif
+}
+/////////////////////////////////////////////////////////////////////
+// モジュール名 logWriteTask
+// 処理概要     SD書き込み要求処理
+// 引数         なし
+// 戻り値       なし
+/////////////////////////////////////////////////////////////////////
+void logWriteTask(void)
+{
+#ifdef LOG_RUNNING_WRITE
+        if (logWriteReq)
+        {
+                writeLogPuts();        // 割り込み外でSD書き込みを実行する
+                logWriteReq = false;
+        }
 #endif
 }
 /////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Summary
- queue SD log writes in 100us timer interrupt
- process pending log writes in main loop only during run

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68b41491c22883238672cbd33a05adb4