### PR TITLE
SDカード送信関数でmemcpyを廃止

### DIFF
--- a/robotrace_v2/Core/Src/SDcard.c
+++ b/robotrace_v2/Core/Src/SDcard.c
@@ -719,8 +719,8 @@ void send16bit(uint16_t data)
 {
 	// バイト順を変換して一時変数に格納
 	uint16_t swapped = __builtin_bswap16(data);
-	// アクティブバッファに高速コピー
-	memcpy(&activeBuf[logBuffIndex], &swapped, sizeof(swapped));
+	// バイトスワップ後の値をポインタキャストでバッファへ直接書き込む
+	*(uint16_t *)&activeBuf[logBuffIndex] = swapped;        // 2バイト分をそのまま格納
 	// 書き込み位置を更新
 	logBuffIndex += sizeof(swapped);
 }
@@ -736,8 +736,8 @@ void send32bit(uint32_t data)
 {
 	// バイト順を変換して一時変数に格納
 	uint32_t swapped = __builtin_bswap32(data);
-	// アクティブバッファに高速コピー
-	memcpy(&activeBuf[logBuffIndex], &swapped, sizeof(swapped));
+	// バイトスワップ後の値をポインタキャストでバッファへ直接書き込む
+	*(uint32_t *)&activeBuf[logBuffIndex] = swapped;        // 4バイト分をそのまま格納
 	// 書き込み位置を更新
 	logBuffIndex += sizeof(swapped);
 }


### PR DESCRIPTION
## 概要
- `send16bit`と`send32bit`でバイトスワップ後の値をポインタキャストでバッファへ直接書き込むよう変更
- 直接書き込み部分のコメントを追加し、`logBuffIndex`更新処理を維持

## テスト
- `make` : Makefileが存在せずビルド不可

------
https://chatgpt.com/codex/tasks/task_e_68b4339a1d348323a26a6702ffa0523a