### PR TITLE
Add DMA-based SSD1306 screen update

### DIFF
--- a/robotrace_v2/Core/Inc/ssd1306.h
+++ b/robotrace_v2/Core/Inc/ssd1306.h
@@ -144,6 +144,10 @@ typedef struct {
 void ssd1306_Init(void);
 void ssd1306_Fill(SSD1306_COLOR color);
 void ssd1306_UpdateScreen(void);
+void ssd1306_UpdateScreen_DMA(void); // DMA版画面更新を開始
+uint8_t ssd1306_IsBusy(void);        // DMA転送中フラグ参照
+void ssd1306_TransferCompletedCallback(void); // DMA完了時のコールバック
+void ssd1306_I2C_MemTxCpltCallback(I2C_HandleTypeDef *hi2c); // I2Cメモリ転送完了処理
 void ssd1306_DrawPixel(uint8_t x, uint8_t y, SSD1306_COLOR color);
 char ssd1306_WriteChar(char ch, FontDef Font, SSD1306_COLOR color);
 char ssd1306_WriteString(char* str, FontDef Font, SSD1306_COLOR color);

--- a/robotrace_v2/Core/Src/control.c
+++ b/robotrace_v2/Core/Src/control.c
@@ -110,8 +110,8 @@ void initSystem(void)
 		showBattery();	 // 充電Lv表示
 		ssd1306_SetCursor(0, 16);
 		ssd1306_printf(Font_6x8, "Exboard connect");
-               if (!ssd1306_IsBusy())       // DMA転送中は更新しない
-                       ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
+		if (!ssd1306_IsBusy())       // DMA転送中は更新しない
+			ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
 
 		setLED(0, 0, 50, 0); // 初期化 成功 緑点灯
 	}
@@ -158,8 +158,8 @@ void initSystem(void)
 	}
 	if (modeDSP)
 	{
-           if (!ssd1306_IsBusy())           // DMA転送中は更新しない
-                   ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
+	if (!ssd1306_IsBusy())			// DMA転送中は更新しない
+		ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
 	}
 	sendLED();
 
@@ -184,8 +184,8 @@ void initSystem(void)
 	}
 	if (modeDSP)
 	{
-           if (!ssd1306_IsBusy())           // DMA転送中は更新しない
-                   ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
+	if (!ssd1306_IsBusy())			// DMA転送中は更新しない
+		ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
 	}
 	sendLED();
 
@@ -225,8 +225,8 @@ void initSystem(void)
 	}
 	if (modeDSP)
 	{
-           if (!ssd1306_IsBusy())           // DMA転送中は更新しない
-                   ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
+	if (!ssd1306_IsBusy())			// DMA転送中は更新しない
+		ssd1306_UpdateScreen_DMA();	// グラフィック液晶更新
 	}
 	sendLED();
 
@@ -240,8 +240,8 @@ void initSystem(void)
 			ssd1306_FillRectangle(0, 15, 127, 63, Black); // メイン表示空白埋め
 			ssd1306_SetCursor(15, 30);
 			ssd1306_printf(Font_11x18, "No SDcard");
-                   if (!ssd1306_IsBusy())   // DMA転送中は更新しない
-                           ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
+			if (!ssd1306_IsBusy())			// DMA転送中は更新しない
+				ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
 
 			HAL_Delay(1000);
 		}
@@ -294,8 +294,8 @@ void loopSystem(void)
 			ssd1306_FillRectangle(0, 15, 127, 63, Black); // メイン表示空白埋め
 			ssd1306_SetCursor(0, 25);
 			ssd1306_printf(Font_11x18, "Analizing");
-                   if (!ssd1306_IsBusy())   // DMA転送中は更新しない
-                           ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
+			if (!ssd1306_IsBusy())   // DMA転送中は更新しない
+				ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
 			initIMU = false;
 			numPPADarry = readLogDistance(fileNumbers[fileIndexLog]);
 			optimalIndex = 0;
@@ -305,8 +305,8 @@ void loopSystem(void)
 			ssd1306_FillRectangle(0, 15, 127, 63, Black); // メイン表示空白埋め
 			ssd1306_SetCursor(56, 28);
 			ssd1306_printf(Font_16x26, "2");
-                   if (!ssd1306_IsBusy())   // DMA転送中は更新しない
-                           ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
+			if (!ssd1306_IsBusy())			// DMA転送中は更新しない
+				ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
 			patternTrace = 1;
 		}
 		else
@@ -328,8 +328,8 @@ void loopSystem(void)
 				ssd1306_FillRectangle(0, 15, 127, 63, Black); // メイン表示空白埋め
 				ssd1306_SetCursor(56, 28);
 				ssd1306_printf(Font_16x26, "5");
-                           if (!ssd1306_IsBusy()) // DMA転送中は更新しない
-                                   ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
+				if (!ssd1306_IsBusy())			// DMA転送中は更新しない
+					ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
 				patternTrace = 1;
 			}
 		}
@@ -344,32 +344,32 @@ void loopSystem(void)
 				ssd1306_FillRectangle(0, 15, 127, 63, Black); // メイン表示空白埋め
 				ssd1306_SetCursor(56, 28);
 				ssd1306_printf(Font_16x26, "4");
-                           if (!ssd1306_IsBusy()) // DMA転送中は更新しない
-                                   ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
+				if (!ssd1306_IsBusy())			// DMA転送中は更新しない
+					ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
 			}
 			if (countdown == 3000)
 			{
 				ssd1306_FillRectangle(0, 15, 127, 63, Black); // メイン表示空白埋め
 				ssd1306_SetCursor(56, 28);
 				ssd1306_printf(Font_16x26, "3");
-                           if (!ssd1306_IsBusy()) // DMA転送中は更新しない
-                                   ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
+				if (!ssd1306_IsBusy())			// DMA転送中は更新しない
+					ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
 			}
 			if (countdown == 2000)
 			{
 				ssd1306_FillRectangle(0, 15, 127, 63, Black); // メイン表示空白埋め
 				ssd1306_SetCursor(56, 28);
 				ssd1306_printf(Font_16x26, "2");
-                           if (!ssd1306_IsBusy()) // DMA転送中は更新しない
-                                   ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
+				if (!ssd1306_IsBusy())			// DMA転送中は更新しない
+					ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
 			}
 			if (countdown == 1000)
 			{
 				ssd1306_FillRectangle(0, 15, 127, 63, Black); // メイン表示空白埋め
 				ssd1306_SetCursor(56, 28);
 				ssd1306_printf(Font_16x26, "1");
-                           if (!ssd1306_IsBusy()) // DMA転送中は更新しない
-                                   ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
+				if (!ssd1306_IsBusy())			// DMA転送中は更新しない
+					ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
 				calibratIMU = true;		// IMUキャリブレーションを開始
 			}
 		}
@@ -553,16 +553,16 @@ void loopSystem(void)
 			ssd1306_printf(Font_11x18, "log");
 			ssd1306_SetCursor(0, 45);
 			ssd1306_printf(Font_11x18, "Writing");
-                   if (!ssd1306_IsBusy())   // DMA転送中は更新しない
-                           ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
+			if (!ssd1306_IsBusy())			// DMA転送中は更新しない
+				ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
 
 			if (modeLOG)
 				endLog(); // ログ保存終了
 
 			ssd1306_SetCursor(0, 45);
 			ssd1306_printf(Font_11x18, "Written");
-                   if (!ssd1306_IsBusy())   // DMA転送中は更新しない
-                           ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
+			if (!ssd1306_IsBusy())			// DMA転送中は更新しない
+				ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
 
 			if (autoStart > 0)
 			{
@@ -590,8 +590,8 @@ void loopSystem(void)
 					ssd1306_printf(Font_11x18, "Auto run");
 					ssd1306_SetCursor(0, 45);
 					ssd1306_printf(Font_11x18, "Finish!");
-                                   if (!ssd1306_IsBusy()) // DMA転送中は更新しない
-                                           ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
+					if (!ssd1306_IsBusy())			// DMA転送中は更新しない
+						ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
 					patternTrace = 102;
 					break;
 				}
@@ -623,8 +623,8 @@ void loopSystem(void)
 						ssd1306_SetCursor(0, 45);
 						ssd1306_printf(Font_11x18, "%6.3f[s]", (float)goalTime / 1000);
 					}
-                                   if (!ssd1306_IsBusy()) // DMA転送中は更新しない
-                                           ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
+					if (!ssd1306_IsBusy())			// DMA転送中は更新しない
+						ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
 				}
 			}
 
@@ -687,8 +687,8 @@ void emargencyStop(void)
 			break;
 		}
 
-           if (!ssd1306_IsBusy())           // DMA転送中は更新しない
-                   ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
+		if (!ssd1306_IsBusy())           // DMA転送中は更新しない
+			ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
 	}
 
 	patternTrace = 102;

--- a/robotrace_v2/Core/Src/control.c
+++ b/robotrace_v2/Core/Src/control.c
@@ -110,7 +110,8 @@ void initSystem(void)
 		showBattery();	 // 充電Lv表示
 		ssd1306_SetCursor(0, 16);
 		ssd1306_printf(Font_6x8, "Exboard connect");
-		ssd1306_UpdateScreen();
+               if (!ssd1306_IsBusy())       // DMA転送中は更新しない
+                       ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
 
 		setLED(0, 0, 50, 0); // 初期化 成功 緑点灯
 	}
@@ -157,7 +158,8 @@ void initSystem(void)
 	}
 	if (modeDSP)
 	{
-		ssd1306_UpdateScreen(); // グラフィック液晶更新
+           if (!ssd1306_IsBusy())           // DMA転送中は更新しない
+                   ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
 	}
 	sendLED();
 
@@ -182,7 +184,8 @@ void initSystem(void)
 	}
 	if (modeDSP)
 	{
-		ssd1306_UpdateScreen(); // グラフィック液晶更新
+           if (!ssd1306_IsBusy())           // DMA転送中は更新しない
+                   ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
 	}
 	sendLED();
 
@@ -222,7 +225,8 @@ void initSystem(void)
 	}
 	if (modeDSP)
 	{
-		ssd1306_UpdateScreen(); // グラフィック液晶更新
+           if (!ssd1306_IsBusy())           // DMA転送中は更新しない
+                   ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
 	}
 	sendLED();
 
@@ -236,7 +240,8 @@ void initSystem(void)
 			ssd1306_FillRectangle(0, 15, 127, 63, Black); // メイン表示空白埋め
 			ssd1306_SetCursor(15, 30);
 			ssd1306_printf(Font_11x18, "No SDcard");
-			ssd1306_UpdateScreen(); // グラフィック液晶更新
+                   if (!ssd1306_IsBusy())   // DMA転送中は更新しない
+                           ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
 
 			HAL_Delay(1000);
 		}
@@ -289,7 +294,8 @@ void loopSystem(void)
 			ssd1306_FillRectangle(0, 15, 127, 63, Black); // メイン表示空白埋め
 			ssd1306_SetCursor(0, 25);
 			ssd1306_printf(Font_11x18, "Analizing");
-			ssd1306_UpdateScreen(); // グラフィック液晶更新
+                   if (!ssd1306_IsBusy())   // DMA転送中は更新しない
+                           ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
 			initIMU = false;
 			numPPADarry = readLogDistance(fileNumbers[fileIndexLog]);
 			optimalIndex = 0;
@@ -299,7 +305,8 @@ void loopSystem(void)
 			ssd1306_FillRectangle(0, 15, 127, 63, Black); // メイン表示空白埋め
 			ssd1306_SetCursor(56, 28);
 			ssd1306_printf(Font_16x26, "2");
-			ssd1306_UpdateScreen(); // グラフィック液晶更新
+                   if (!ssd1306_IsBusy())   // DMA転送中は更新しない
+                           ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
 			patternTrace = 1;
 		}
 		else
@@ -321,7 +328,8 @@ void loopSystem(void)
 				ssd1306_FillRectangle(0, 15, 127, 63, Black); // メイン表示空白埋め
 				ssd1306_SetCursor(56, 28);
 				ssd1306_printf(Font_16x26, "5");
-				ssd1306_UpdateScreen(); // グラフィック液晶更新
+                           if (!ssd1306_IsBusy()) // DMA転送中は更新しない
+                                   ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
 				patternTrace = 1;
 			}
 		}
@@ -336,28 +344,32 @@ void loopSystem(void)
 				ssd1306_FillRectangle(0, 15, 127, 63, Black); // メイン表示空白埋め
 				ssd1306_SetCursor(56, 28);
 				ssd1306_printf(Font_16x26, "4");
-				ssd1306_UpdateScreen(); // グラフィック液晶更新
+                           if (!ssd1306_IsBusy()) // DMA転送中は更新しない
+                                   ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
 			}
 			if (countdown == 3000)
 			{
 				ssd1306_FillRectangle(0, 15, 127, 63, Black); // メイン表示空白埋め
 				ssd1306_SetCursor(56, 28);
 				ssd1306_printf(Font_16x26, "3");
-				ssd1306_UpdateScreen(); // グラフィック液晶更新
+                           if (!ssd1306_IsBusy()) // DMA転送中は更新しない
+                                   ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
 			}
 			if (countdown == 2000)
 			{
 				ssd1306_FillRectangle(0, 15, 127, 63, Black); // メイン表示空白埋め
 				ssd1306_SetCursor(56, 28);
 				ssd1306_printf(Font_16x26, "2");
-				ssd1306_UpdateScreen(); // グラフィック液晶更新
+                           if (!ssd1306_IsBusy()) // DMA転送中は更新しない
+                                   ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
 			}
 			if (countdown == 1000)
 			{
 				ssd1306_FillRectangle(0, 15, 127, 63, Black); // メイン表示空白埋め
 				ssd1306_SetCursor(56, 28);
 				ssd1306_printf(Font_16x26, "1");
-				ssd1306_UpdateScreen(); // グラフィック液晶更新
+                           if (!ssd1306_IsBusy()) // DMA転送中は更新しない
+                                   ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
 				calibratIMU = true;		// IMUキャリブレーションを開始
 			}
 		}
@@ -541,14 +553,16 @@ void loopSystem(void)
 			ssd1306_printf(Font_11x18, "log");
 			ssd1306_SetCursor(0, 45);
 			ssd1306_printf(Font_11x18, "Writing");
-			ssd1306_UpdateScreen(); // グラフィック液晶更新
+                   if (!ssd1306_IsBusy())   // DMA転送中は更新しない
+                           ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
 
 			if (modeLOG)
 				endLog(); // ログ保存終了
 
 			ssd1306_SetCursor(0, 45);
 			ssd1306_printf(Font_11x18, "Written");
-			ssd1306_UpdateScreen(); // グラフィック液晶更新
+                   if (!ssd1306_IsBusy())   // DMA転送中は更新しない
+                           ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
 
 			if (autoStart > 0)
 			{
@@ -576,7 +590,8 @@ void loopSystem(void)
 					ssd1306_printf(Font_11x18, "Auto run");
 					ssd1306_SetCursor(0, 45);
 					ssd1306_printf(Font_11x18, "Finish!");
-					ssd1306_UpdateScreen(); // グラフィック液晶更新
+                                   if (!ssd1306_IsBusy()) // DMA転送中は更新しない
+                                           ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
 					patternTrace = 102;
 					break;
 				}
@@ -608,7 +623,8 @@ void loopSystem(void)
 						ssd1306_SetCursor(0, 45);
 						ssd1306_printf(Font_11x18, "%6.3f[s]", (float)goalTime / 1000);
 					}
-					ssd1306_UpdateScreen(); // グラフィック液晶更新
+                                   if (!ssd1306_IsBusy()) // DMA転送中は更新しない
+                                           ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
 				}
 			}
 
@@ -671,7 +687,8 @@ void emargencyStop(void)
 			break;
 		}
 
-		ssd1306_UpdateScreen(); // グラフィック液晶更新
+           if (!ssd1306_IsBusy())           // DMA転送中は更新しない
+                   ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
 	}
 
 	patternTrace = 102;

--- a/robotrace_v2/Core/Src/main.c
+++ b/robotrace_v2/Core/Src/main.c
@@ -23,6 +23,8 @@
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
 
+/* SSD1306制御用ヘッダ */
+#include "ssd1306.h"
 /* USER CODE END Includes */
 
 /* Private typedef -----------------------------------------------------------*/
@@ -1052,20 +1054,26 @@ void HAL_TIM_PWM_PulseFinishedCallback(TIM_HandleTypeDef *htim)
 
 void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim)
 {
-	if (htim->Instance == TIM6)
-	{
-		Interrupt1ms();
-	}
-	if (htim->Instance == TIM7)
-	{
-		Interrupt100us();
-	}
+        if (htim->Instance == TIM6)
+        {
+                Interrupt1ms();
+        }
+        if (htim->Instance == TIM7)
+        {
+                Interrupt100us();
+        }
+}
+
+/* I2Cメモリ転送完了割り込み */
+void HAL_I2C_MemTxCpltCallback(I2C_HandleTypeDef *hi2c)
+{
+       ssd1306_I2C_MemTxCpltCallback(hi2c); // SSD1306のDMA完了処理へ委譲
 }
 
 int _write(int file, char *ptr, int len)
 {
-	int DataIdx;
-	for (DataIdx = 0; DataIdx < len; DataIdx++)
+        int DataIdx;
+        for (DataIdx = 0; DataIdx < len; DataIdx++)
 	{
 		ITM_SendChar(*ptr++);
 	}

--- a/robotrace_v2/Core/Src/main.c
+++ b/robotrace_v2/Core/Src/main.c
@@ -1054,26 +1054,26 @@ void HAL_TIM_PWM_PulseFinishedCallback(TIM_HandleTypeDef *htim)
 
 void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim)
 {
-        if (htim->Instance == TIM6)
-        {
-                Interrupt1ms();
-        }
-        if (htim->Instance == TIM7)
-        {
-                Interrupt100us();
-        }
+	if (htim->Instance == TIM6)
+	{
+		Interrupt1ms();
+	}
+	if (htim->Instance == TIM7)
+	{
+		Interrupt100us();
+	}
 }
 
 /* I2Cメモリ転送完了割り込み */
 void HAL_I2C_MemTxCpltCallback(I2C_HandleTypeDef *hi2c)
 {
-       ssd1306_I2C_MemTxCpltCallback(hi2c); // SSD1306のDMA完了処理へ委譲
+	ssd1306_I2C_MemTxCpltCallback(hi2c); // SSD1306のDMA完了処理へ委譲
 }
 
 int _write(int file, char *ptr, int len)
 {
-        int DataIdx;
-        for (DataIdx = 0; DataIdx < len; DataIdx++)
+	int DataIdx;
+	for (DataIdx = 0; DataIdx < len; DataIdx++)
 	{
 		ITM_SendChar(*ptr++);
 	}

--- a/robotrace_v2/Core/Src/ssd1306.c
+++ b/robotrace_v2/Core/Src/ssd1306.c
@@ -264,7 +264,7 @@ void ssd1306_I2C_MemTxCpltCallback(I2C_HandleTypeDef *hi2c)
 
 __weak void ssd1306_TransferCompletedCallback(void)
 {
-        // ユーザー定義の処理をここに追加
+	// ユーザー定義の処理をここに追加
 }
 #endif
 

--- a/robotrace_v2/Core/Src/ssd1306.c
+++ b/robotrace_v2/Core/Src/ssd1306.c
@@ -19,13 +19,13 @@ void ssd1306_WriteCommand(uint8_t byte)
 // Send data
 void ssd1306_WriteData(uint8_t *buffer, size_t buff_size)
 {
-        HAL_I2C_Mem_Write(&SSD1306_I2C_PORT, SSD1306_I2C_ADDR, 0x40, 1, buffer, buff_size, HAL_MAX_DELAY);
+	HAL_I2C_Mem_Write(&SSD1306_I2C_PORT, SSD1306_I2C_ADDR, 0x40, 1, buffer, buff_size, HAL_MAX_DELAY);
 }
 
 // Send data using DMA
 void ssd1306_WriteData_DMA(uint8_t *buffer, size_t buff_size)
 {
-        HAL_I2C_Mem_Write_DMA(&SSD1306_I2C_PORT, SSD1306_I2C_ADDR, 0x40, 1, buffer, buff_size); // DMA送信開始
+	HAL_I2C_Mem_Write_DMA(&SSD1306_I2C_PORT, SSD1306_I2C_ADDR, 0x40, 1, buffer, buff_size); // DMA送信開始
 }
 
 #elif defined(SSD1306_USE_SPI)
@@ -220,46 +220,46 @@ void ssd1306_UpdateScreen(void)
 #if defined(SSD1306_USE_I2C)
 void ssd1306_UpdateScreen_DMA(void)
 {
-        if (SSD1306_DMA_Busy) // 既に転送中なら無視
-        {
-                return;
-        }
+	if (SSD1306_DMA_Busy) // 既に転送中なら無視
+	{
+		return;
+	}
 
-        SSD1306_DMA_Busy = 1;     // 転送中フラグ設定
-        SSD1306_DMA_Page = 0;     // 0ページ目から送信開始
+	SSD1306_DMA_Busy = 1;     // 転送中フラグ設定
+	SSD1306_DMA_Page = 0;     // 0ページ目から送信開始
 
-        ssd1306_WriteCommand(0xB0 + SSD1306_DMA_Page); // ページアドレス設定
-        ssd1306_WriteCommand(0x00 + SSD1306_X_OFFSET_LOWER); // 列アドレス下位設定
-        ssd1306_WriteCommand(0x10 + SSD1306_X_OFFSET_UPPER); // 列アドレス上位設定
-        ssd1306_WriteData_DMA(&SSD1306_Buffer[SSD1306_WIDTH * SSD1306_DMA_Page], SSD1306_WIDTH); // DMA送信
+	ssd1306_WriteCommand(0xB0 + SSD1306_DMA_Page); // ページアドレス設定
+	ssd1306_WriteCommand(0x00 + SSD1306_X_OFFSET_LOWER); // 列アドレス下位設定
+	ssd1306_WriteCommand(0x10 + SSD1306_X_OFFSET_UPPER); // 列アドレス上位設定
+	ssd1306_WriteData_DMA(&SSD1306_Buffer[SSD1306_WIDTH * SSD1306_DMA_Page], SSD1306_WIDTH); // DMA送信
 }
 
 uint8_t ssd1306_IsBusy(void)
 {
-        return SSD1306_DMA_Busy; // 転送中状態を返す
+	return SSD1306_DMA_Busy; // 転送中状態を返す
 }
 
 void ssd1306_I2C_MemTxCpltCallback(I2C_HandleTypeDef *hi2c)
 {
-       if (hi2c != &SSD1306_I2C_PORT) // 他デバイスの割り込みは無視
-       {
-               return;
-       }
+	if (hi2c != &SSD1306_I2C_PORT) // 他デバイスの割り込みは無視
+	{
+		return;
+	}
 
-       SSD1306_DMA_Page++; // 次のページへ
+	SSD1306_DMA_Page++; // 次のページへ
 
-       if (SSD1306_DMA_Page >= SSD1306_HEIGHT / 8)
-       {
-               SSD1306_DMA_Busy = 0; // 全ページ送信完了
-               ssd1306_TransferCompletedCallback(); // 完了通知
-       }
-       else
-       {
-               ssd1306_WriteCommand(0xB0 + SSD1306_DMA_Page); // 次のページ設定
-               ssd1306_WriteCommand(0x00 + SSD1306_X_OFFSET_LOWER); // 列アドレス下位設定
-               ssd1306_WriteCommand(0x10 + SSD1306_X_OFFSET_UPPER); // 列アドレス上位設定
-               ssd1306_WriteData_DMA(&SSD1306_Buffer[SSD1306_WIDTH * SSD1306_DMA_Page], SSD1306_WIDTH); // DMA送信
-       }
+	if (SSD1306_DMA_Page >= SSD1306_HEIGHT / 8)
+	{
+		SSD1306_DMA_Busy = 0; 					// 全ページ送信完了
+		ssd1306_TransferCompletedCallback();	// 完了通知
+	}
+	else
+	{
+		ssd1306_WriteCommand(0xB0 + SSD1306_DMA_Page); 			// 次のページ設定
+		ssd1306_WriteCommand(0x00 + SSD1306_X_OFFSET_LOWER);	// 列アドレス下位設定
+		ssd1306_WriteCommand(0x10 + SSD1306_X_OFFSET_UPPER);	// 列アドレス上位設定
+		ssd1306_WriteData_DMA(&SSD1306_Buffer[SSD1306_WIDTH * SSD1306_DMA_Page], SSD1306_WIDTH); // DMA送信
+	}
 }
 
 __weak void ssd1306_TransferCompletedCallback(void)

--- a/robotrace_v2/Core/Src/ssd1306.c
+++ b/robotrace_v2/Core/Src/ssd1306.c
@@ -19,7 +19,13 @@ void ssd1306_WriteCommand(uint8_t byte)
 // Send data
 void ssd1306_WriteData(uint8_t *buffer, size_t buff_size)
 {
-	HAL_I2C_Mem_Write(&SSD1306_I2C_PORT, SSD1306_I2C_ADDR, 0x40, 1, buffer, buff_size, HAL_MAX_DELAY);
+        HAL_I2C_Mem_Write(&SSD1306_I2C_PORT, SSD1306_I2C_ADDR, 0x40, 1, buffer, buff_size, HAL_MAX_DELAY);
+}
+
+// Send data using DMA
+void ssd1306_WriteData_DMA(uint8_t *buffer, size_t buff_size)
+{
+        HAL_I2C_Mem_Write_DMA(&SSD1306_I2C_PORT, SSD1306_I2C_ADDR, 0x40, 1, buffer, buff_size); // DMA送信開始
 }
 
 #elif defined(SSD1306_USE_SPI)
@@ -63,6 +69,9 @@ static uint8_t SSD1306_Buffer[SSD1306_BUFFER_SIZE];
 
 // Screen object
 static SSD1306_t SSD1306;
+
+static volatile uint8_t SSD1306_DMA_Busy = 0; // DMA転送中フラグ
+static uint8_t SSD1306_DMA_Page = 0;          // 送信中のページ番号
 
 /* Fills the Screenbuffer with values from a given buffer of a fixed length */
 SSD1306_Error_t ssd1306_FillBuffer(uint8_t *buf, uint32_t len)
@@ -207,6 +216,57 @@ void ssd1306_UpdateScreen(void)
 		ssd1306_WriteData(&SSD1306_Buffer[SSD1306_WIDTH * i], SSD1306_WIDTH);
 	}
 }
+
+#if defined(SSD1306_USE_I2C)
+void ssd1306_UpdateScreen_DMA(void)
+{
+        if (SSD1306_DMA_Busy) // 既に転送中なら無視
+        {
+                return;
+        }
+
+        SSD1306_DMA_Busy = 1;     // 転送中フラグ設定
+        SSD1306_DMA_Page = 0;     // 0ページ目から送信開始
+
+        ssd1306_WriteCommand(0xB0 + SSD1306_DMA_Page); // ページアドレス設定
+        ssd1306_WriteCommand(0x00 + SSD1306_X_OFFSET_LOWER); // 列アドレス下位設定
+        ssd1306_WriteCommand(0x10 + SSD1306_X_OFFSET_UPPER); // 列アドレス上位設定
+        ssd1306_WriteData_DMA(&SSD1306_Buffer[SSD1306_WIDTH * SSD1306_DMA_Page], SSD1306_WIDTH); // DMA送信
+}
+
+uint8_t ssd1306_IsBusy(void)
+{
+        return SSD1306_DMA_Busy; // 転送中状態を返す
+}
+
+void ssd1306_I2C_MemTxCpltCallback(I2C_HandleTypeDef *hi2c)
+{
+       if (hi2c != &SSD1306_I2C_PORT) // 他デバイスの割り込みは無視
+       {
+               return;
+       }
+
+       SSD1306_DMA_Page++; // 次のページへ
+
+       if (SSD1306_DMA_Page >= SSD1306_HEIGHT / 8)
+       {
+               SSD1306_DMA_Busy = 0; // 全ページ送信完了
+               ssd1306_TransferCompletedCallback(); // 完了通知
+       }
+       else
+       {
+               ssd1306_WriteCommand(0xB0 + SSD1306_DMA_Page); // 次のページ設定
+               ssd1306_WriteCommand(0x00 + SSD1306_X_OFFSET_LOWER); // 列アドレス下位設定
+               ssd1306_WriteCommand(0x10 + SSD1306_X_OFFSET_UPPER); // 列アドレス上位設定
+               ssd1306_WriteData_DMA(&SSD1306_Buffer[SSD1306_WIDTH * SSD1306_DMA_Page], SSD1306_WIDTH); // DMA送信
+       }
+}
+
+__weak void ssd1306_TransferCompletedCallback(void)
+{
+        // ユーザー定義の処理をここに追加
+}
+#endif
 
 /*
  * Draw one pixel in the screenbuffer


### PR DESCRIPTION
## Summary
- add DMA-aware screen update and busy flag to SSD1306 driver
- implement I2C DMA state machine and completion callback
- update control logic to use DMA update and skip calls when busy
- move HAL I2C DMA completion callback to main and delegate to SSD1306 handler

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5184a19f88323b8067d0582d65296