### PR TITLE
SSD1306 DMA連続更新の完了フラグAPI導入

### DIFF
--- a/robotrace_v2/Core/Inc/ssd1306.h
+++ b/robotrace_v2/Core/Inc/ssd1306.h
@@ -102,6 +102,8 @@ extern SPI_HandleTypeDef SSD1306_SPI_PORT;
 #error "You should define SSD1306_USE_SPI or SSD1306_USE_I2C macro!"
 #endif
 
+extern volatile uint8_t SSD1306_DMA_Completed; // 全ページ送信完了フラグ
+
 // SSD1306 OLED height in pixels
 #ifndef SSD1306_HEIGHT
 #define SSD1306_HEIGHT          64
@@ -145,7 +147,7 @@ void ssd1306_Init(void);
 void ssd1306_Fill(SSD1306_COLOR color);
 void ssd1306_UpdateScreen(void);
 void ssd1306_UpdateScreen_DMA(void); // DMA版画面更新を開始
-uint8_t ssd1306_IsBusy(void);        // DMA転送中フラグ参照
+uint8_t ssd1306_IsTransferCompleted(void); // 全ページ送信完了フラグ参照
 void ssd1306_TransferCompletedCallback(void); // DMA完了時のコールバック
 void ssd1306_I2C_MemTxCpltCallback(I2C_HandleTypeDef *hi2c); // I2Cメモリ転送完了処理
 void ssd1306_DrawPixel(uint8_t x, uint8_t y, SSD1306_COLOR color);

--- a/robotrace_v2/Core/Src/control.c
+++ b/robotrace_v2/Core/Src/control.c
@@ -157,7 +157,8 @@ void initSystem(void)
 	}
 	if (modeDSP)
 	{
-		while(ssd1306_IsBusy());	// ディスプレイ更新完了まで待つ
+		SSD1306_DMA_Completed = 0; // 全ページ送信完了フラグリセット
+		while(!ssd1306_IsTransferCompleted());	// 全ページ送信完了まで待つ
 		HAL_Delay(500);
 	}
 	sendLED();
@@ -183,7 +184,8 @@ void initSystem(void)
 	}
 	if (modeDSP)
 	{
-		while(ssd1306_IsBusy());	// ディスプレイ更新完了まで待つ
+		SSD1306_DMA_Completed = 0; // 全ページ送信完了フラグリセット
+		while(!ssd1306_IsTransferCompleted());	// 全ページ送信完了まで待つ
 		HAL_Delay(500);
 	}
 	sendLED();
@@ -224,7 +226,8 @@ void initSystem(void)
 	}
 	if (modeDSP)
 	{
-		while(ssd1306_IsBusy());	// ディスプレイ更新完了まで待つ
+		SSD1306_DMA_Completed = 0; // 全ページ送信完了フラグリセット
+		while(!ssd1306_IsTransferCompleted());	// 全ページ送信完了まで待つ
 		HAL_Delay(500);
 	}
 	sendLED();
@@ -239,7 +242,8 @@ void initSystem(void)
 			ssd1306_FillRectangle(0, 15, 127, 63, Black); // メイン表示空白埋め
 			ssd1306_SetCursor(15, 30);
 			ssd1306_printf(Font_11x18, "No SDcard");
-			while(ssd1306_IsBusy());	// ディスプレイ更新完了まで待つ
+			SSD1306_DMA_Completed = 0; // 全ページ送信完了フラグリセット
+			while(!ssd1306_IsTransferCompleted());	// 全ページ送信完了まで待つ
 
 			HAL_Delay(1000);
 		}
@@ -292,7 +296,7 @@ void loopSystem(void)
 			ssd1306_FillRectangle(0, 15, 127, 63, Black); // メイン表示空白埋め
 			ssd1306_SetCursor(0, 25);
 			ssd1306_printf(Font_11x18, "Analizing");
-			if (!ssd1306_IsBusy())   // DMA転送中は更新しない
+			if (ssd1306_IsTransferCompleted())	// 全ページ送信完了時のみ画面更新
 				ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
 			initIMU = false;
 			numPPADarry = readLogDistance(fileNumbers[fileIndexLog]);
@@ -303,7 +307,7 @@ void loopSystem(void)
 			ssd1306_FillRectangle(0, 15, 127, 63, Black); // メイン表示空白埋め
 			ssd1306_SetCursor(56, 28);
 			ssd1306_printf(Font_16x26, "2");
-			if (!ssd1306_IsBusy())			// DMA転送中は更新しない
+			if (ssd1306_IsTransferCompleted())	// 全ページ送信完了時のみ画面更新
 				ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
 			patternTrace = 1;
 		}
@@ -326,7 +330,7 @@ void loopSystem(void)
 				ssd1306_FillRectangle(0, 15, 127, 63, Black); // メイン表示空白埋め
 				ssd1306_SetCursor(56, 28);
 				ssd1306_printf(Font_16x26, "5");
-				if (!ssd1306_IsBusy())			// DMA転送中は更新しない
+				if (ssd1306_IsTransferCompleted())	// 全ページ送信完了時のみ画面更新
 					ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
 				patternTrace = 1;
 			}
@@ -342,7 +346,7 @@ void loopSystem(void)
 				ssd1306_FillRectangle(0, 15, 127, 63, Black); // メイン表示空白埋め
 				ssd1306_SetCursor(56, 28);
 				ssd1306_printf(Font_16x26, "4");
-				if (!ssd1306_IsBusy())			// DMA転送中は更新しない
+				if (ssd1306_IsTransferCompleted())	// 全ページ送信完了時のみ画面更新
 					ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
 			}
 			if (countdown == 3000)
@@ -350,7 +354,7 @@ void loopSystem(void)
 				ssd1306_FillRectangle(0, 15, 127, 63, Black); // メイン表示空白埋め
 				ssd1306_SetCursor(56, 28);
 				ssd1306_printf(Font_16x26, "3");
-				if (!ssd1306_IsBusy())			// DMA転送中は更新しない
+				if (ssd1306_IsTransferCompleted())	// 全ページ送信完了時のみ画面更新
 					ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
 			}
 			if (countdown == 2000)
@@ -358,7 +362,7 @@ void loopSystem(void)
 				ssd1306_FillRectangle(0, 15, 127, 63, Black); // メイン表示空白埋め
 				ssd1306_SetCursor(56, 28);
 				ssd1306_printf(Font_16x26, "2");
-				if (!ssd1306_IsBusy())			// DMA転送中は更新しない
+				if (ssd1306_IsTransferCompleted())	// 全ページ送信完了時のみ画面更新
 					ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
 			}
 			if (countdown == 1000)
@@ -366,7 +370,7 @@ void loopSystem(void)
 				ssd1306_FillRectangle(0, 15, 127, 63, Black); // メイン表示空白埋め
 				ssd1306_SetCursor(56, 28);
 				ssd1306_printf(Font_16x26, "1");
-				if (!ssd1306_IsBusy())			// DMA転送中は更新しない
+				if (ssd1306_IsTransferCompleted())	// 全ページ送信完了時のみ画面更新
 					ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
 				calibratIMU = true;		// IMUキャリブレーションを開始
 			}
@@ -551,7 +555,7 @@ void loopSystem(void)
 			ssd1306_printf(Font_11x18, "log");
 			ssd1306_SetCursor(0, 45);
 			ssd1306_printf(Font_11x18, "Writing");
-			if (!ssd1306_IsBusy())			// DMA転送中は更新しない
+			if (ssd1306_IsTransferCompleted())	// 全ページ送信完了時のみ画面更新
 				ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
 
 			if (modeLOG)
@@ -559,7 +563,7 @@ void loopSystem(void)
 
 			ssd1306_SetCursor(0, 45);
 			ssd1306_printf(Font_11x18, "Written");
-			if (!ssd1306_IsBusy())			// DMA転送中は更新しない
+			if (ssd1306_IsTransferCompleted())	// 全ページ送信完了時のみ画面更新
 				ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
 
 			if (autoStart > 0)
@@ -588,7 +592,7 @@ void loopSystem(void)
 					ssd1306_printf(Font_11x18, "Auto run");
 					ssd1306_SetCursor(0, 45);
 					ssd1306_printf(Font_11x18, "Finish!");
-					if (!ssd1306_IsBusy())			// DMA転送中は更新しない
+					if (ssd1306_IsTransferCompleted())	// 全ページ送信完了時のみ画面更新
 						ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
 					patternTrace = 102;
 					break;
@@ -621,7 +625,7 @@ void loopSystem(void)
 						ssd1306_SetCursor(0, 45);
 						ssd1306_printf(Font_11x18, "%6.3f[s]", (float)goalTime / 1000);
 					}
-					if (!ssd1306_IsBusy())			// DMA転送中は更新しない
+					if (ssd1306_IsTransferCompleted())	// 全ページ送信完了時のみ画面更新
 						ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
 				}
 			}
@@ -685,7 +689,7 @@ void emargencyStop(void)
 			break;
 		}
 
-		if (!ssd1306_IsBusy())           // DMA転送中は更新しない
+		if (ssd1306_IsTransferCompleted())	// 全ページ送信完了時のみ画面更新
 			ssd1306_UpdateScreen_DMA(); // グラフィック液晶更新
 	}
 

--- a/robotrace_v2/Core/Src/control.c
+++ b/robotrace_v2/Core/Src/control.c
@@ -157,9 +157,8 @@ void initSystem(void)
 	}
 	if (modeDSP)
 	{
-		SSD1306_DMA_Completed = 0; // 全ページ送信完了フラグリセット
+		SSD1306_DMA_Completed = 0;				// 全ページ送信完了フラグリセット
 		while(!ssd1306_IsTransferCompleted());	// 全ページ送信完了まで待つ
-		HAL_Delay(500);
 	}
 	sendLED();
 
@@ -184,9 +183,8 @@ void initSystem(void)
 	}
 	if (modeDSP)
 	{
-		SSD1306_DMA_Completed = 0; // 全ページ送信完了フラグリセット
+		SSD1306_DMA_Completed = 0;				// 全ページ送信完了フラグリセット
 		while(!ssd1306_IsTransferCompleted());	// 全ページ送信完了まで待つ
-		HAL_Delay(500);
 	}
 	sendLED();
 
@@ -226,9 +224,8 @@ void initSystem(void)
 	}
 	if (modeDSP)
 	{
-		SSD1306_DMA_Completed = 0; // 全ページ送信完了フラグリセット
+		SSD1306_DMA_Completed = 0;				// 全ページ送信完了フラグリセット
 		while(!ssd1306_IsTransferCompleted());	// 全ページ送信完了まで待つ
-		HAL_Delay(500);
 	}
 	sendLED();
 

--- a/robotrace_v2/Core/Src/ssd1306.c
+++ b/robotrace_v2/Core/Src/ssd1306.c
@@ -14,8 +14,8 @@ static uint8_t SSD1306_Buffer[SSD1306_BUFFER_SIZE];
 // Screen object
 static SSD1306_t SSD1306;
 
-static volatile uint8_t SSD1306_DMA_Busy = 0; // DMA転送中フラグ
 static uint8_t SSD1306_DMA_Page = 0;          // 送信中のページ番号
+volatile uint8_t SSD1306_DMA_Completed = 0;   // 全ページ送信完了フラグ
 #if defined(SSD1306_USE_I2C)
 /////////////////////////////////////////////////////////////////////
 // モジュール名 ssd1306_Reset
@@ -273,13 +273,8 @@ void ssd1306_UpdateScreen(void)
 /////////////////////////////////////////////////////////////////////
 void ssd1306_UpdateScreen_DMA(void)
 {
-	if (SSD1306_DMA_Busy) // 既に転送中なら無視
-	{
-		return;
-	}
-
-	SSD1306_DMA_Busy = 1;     // 転送中フラグ設定
-	SSD1306_DMA_Page = 0;     // 0ページ目から送信開始
+        SSD1306_DMA_Page = 0;     // 0ページ目から送信開始
+        SSD1306_DMA_Completed = 0; // 送信開始前に完了フラグをリセット
 
 	ssd1306_WriteCommand(0xB0 + SSD1306_DMA_Page); // ページアドレス設定
 	ssd1306_WriteCommand(0x00 + SSD1306_X_OFFSET_LOWER); // 列アドレス下位設定
@@ -287,14 +282,14 @@ void ssd1306_UpdateScreen_DMA(void)
 	ssd1306_WriteData_DMA(&SSD1306_Buffer[SSD1306_WIDTH * SSD1306_DMA_Page], SSD1306_WIDTH); // DMA送信
 }
 /////////////////////////////////////////////////////////////////////
-// モジュール名 ssd1306_IsBusy
-// 処理概要     DMA転送中状態の参照
+// モジュール名 ssd1306_IsTransferCompleted
+// 処理概要     全ページ送信完了状態の参照
 // 引数         なし
-// 戻り値       DMA転送中状態
+// 戻り値       全ページ送信完了状態
 /////////////////////////////////////////////////////////////////////
-uint8_t ssd1306_IsBusy(void)
+uint8_t ssd1306_IsTransferCompleted(void)
 {
-	return SSD1306_DMA_Busy; // 転送中状態を返す
+        return SSD1306_DMA_Completed; // 完了フラグを返す
 }
 /////////////////////////////////////////////////////////////////////
 // モジュール名 ssd1306_I2C_MemTxCpltCallback
@@ -309,20 +304,19 @@ void ssd1306_I2C_MemTxCpltCallback(I2C_HandleTypeDef *hi2c)
 		return;
 	}
 
-	SSD1306_DMA_Page++; // 次のページへ
+        SSD1306_DMA_Page++; // 次のページへ
 
-	if (SSD1306_DMA_Page >= SSD1306_HEIGHT / 8)
-	{
-		SSD1306_DMA_Busy = 0; 					// 全ページ送信完了
-		ssd1306_TransferCompletedCallback();	// 完了通知
-	}
-	else
-	{
-		ssd1306_WriteCommand(0xB0 + SSD1306_DMA_Page); 			// 次のページ設定
-		ssd1306_WriteCommand(0x00 + SSD1306_X_OFFSET_LOWER);	// 列アドレス下位設定
-		ssd1306_WriteCommand(0x10 + SSD1306_X_OFFSET_UPPER);	// 列アドレス上位設定
-		ssd1306_WriteData_DMA(&SSD1306_Buffer[SSD1306_WIDTH * SSD1306_DMA_Page], SSD1306_WIDTH); // DMA送信
-	}
+        if (SSD1306_DMA_Page >= SSD1306_HEIGHT / 8)
+        {
+                SSD1306_DMA_Completed = 1;           // 全ページ送信完了フラグセット
+                ssd1306_TransferCompletedCallback(); // 全ページ送信完了通知
+                SSD1306_DMA_Page = 0;                // 0ページに戻して継続
+        }
+
+	ssd1306_WriteCommand(0xB0 + SSD1306_DMA_Page); // ページアドレス設定
+	ssd1306_WriteCommand(0x00 + SSD1306_X_OFFSET_LOWER); // 列アドレス下位設定
+	ssd1306_WriteCommand(0x10 + SSD1306_X_OFFSET_UPPER); // 列アドレス上位設定
+	ssd1306_WriteData_DMA(&SSD1306_Buffer[SSD1306_WIDTH * SSD1306_DMA_Page], SSD1306_WIDTH); // DMA送信
 }
 /////////////////////////////////////////////////////////////////////
 // モジュール名 ssd1306_TransferCompletedCallback

--- a/robotrace_v2/Core/Src/ssd1306.c
+++ b/robotrace_v2/Core/Src/ssd1306.c
@@ -273,8 +273,8 @@ void ssd1306_UpdateScreen(void)
 /////////////////////////////////////////////////////////////////////
 void ssd1306_UpdateScreen_DMA(void)
 {
-        SSD1306_DMA_Page = 0;     // 0ページ目から送信開始
-        SSD1306_DMA_Completed = 0; // 送信開始前に完了フラグをリセット
+	SSD1306_DMA_Page = 0;     // 0ページ目から送信開始
+	SSD1306_DMA_Completed = 0; // 送信開始前に完了フラグをリセット
 
 	ssd1306_WriteCommand(0xB0 + SSD1306_DMA_Page); // ページアドレス設定
 	ssd1306_WriteCommand(0x00 + SSD1306_X_OFFSET_LOWER); // 列アドレス下位設定
@@ -304,14 +304,14 @@ void ssd1306_I2C_MemTxCpltCallback(I2C_HandleTypeDef *hi2c)
 		return;
 	}
 
-        SSD1306_DMA_Page++; // 次のページへ
+	SSD1306_DMA_Page++; // 次のページへ
 
-        if (SSD1306_DMA_Page >= SSD1306_HEIGHT / 8)
-        {
-                SSD1306_DMA_Completed = 1;           // 全ページ送信完了フラグセット
-                ssd1306_TransferCompletedCallback(); // 全ページ送信完了通知
-                SSD1306_DMA_Page = 0;                // 0ページに戻して継続
-        }
+	if (SSD1306_DMA_Page >= SSD1306_HEIGHT / 8)
+	{
+		SSD1306_DMA_Completed = 1;           // 全ページ送信完了フラグセット
+		ssd1306_TransferCompletedCallback(); // 全ページ送信完了通知
+		SSD1306_DMA_Page = 0;                // 0ページに戻して継続
+	}
 
 	ssd1306_WriteCommand(0xB0 + SSD1306_DMA_Page); // ページアドレス設定
 	ssd1306_WriteCommand(0x00 + SSD1306_X_OFFSET_LOWER); // 列アドレス下位設定


### PR DESCRIPTION
## 概要
- DMA転送完了待ち前に完了フラグをクリアする処理を追加し、次の全ページ送信完了を確実に待機

## テスト
- `make` (Makefile が存在しないため失敗)


------
https://chatgpt.com/codex/tasks/task_e_68bc5269de3083239d96dad3a4106c01