### PR TITLE
モーターPWMの飽和防止処理追加

### DIFF
--- a/robotrace_v2/Core/Src/motor.c
+++ b/robotrace_v2/Core/Src/motor.c
@@ -80,7 +80,13 @@ void motorPwmOutSynth(int16_t tPwm, int16_t sPwm, int16_t yrPwm, int16_t dPwm)
 	}
 
 	motorpwmR = sPwm - tracePwm - yrPwm + dPwm;
+	// PWMの飽和防止
+	if (motorpwmR > 1000) motorpwmR = 1000;
+	else if (motorpwmR < -1000) motorpwmR = -1000;
 	motorpwmL = sPwm + tracePwm + yrPwm + dPwm;
+	// PWMの飽和防止
+	if (motorpwmL > 1000) motorpwmL = 1000;
+	else if (motorpwmL < -1000) motorpwmL = -1000;
 
 	motorPwmOut(motorpwmL, motorpwmR);
 }


### PR DESCRIPTION
## 概要
- motorpwmR と motorpwmL に ±1000 のクリップ処理を追加

## テスト
- `make`（Makefile が存在しないためビルド不可）

------
https://chatgpt.com/codex/tasks/task_e_68bc6fb24c98832381ae71f23581bd09