### PR TITLE
PWM 0時の比較レジスタ設定コメントの明確化

### DIFF
--- a/robotrace_v2/Core/Src/motor.c
+++ b/robotrace_v2/Core/Src/motor.c
@@ -19,11 +19,11 @@ float motorCurrentL, motorCurrentR;
 /////////////////////////////////////////////////////////////////////
 void motorPwmOut(int16_t pwmL, int16_t pwmR)
 {
-	// 0除算回避
-	if (pwmL == 0)
-		__HAL_TIM_SET_COMPARE(&MOTOR_TIM_HANDLER, MOTOR_TIM_CH_L, 0);
-	if (pwmR == 0)
-		__HAL_TIM_SET_COMPARE(&MOTOR_TIM_HANDLER, MOTOR_TIM_CH_R, 0);
+        // PWM が 0 のとき比較レジスタを 0 に設定
+        if (pwmL == 0)
+                __HAL_TIM_SET_COMPARE(&MOTOR_TIM_HANDLER, MOTOR_TIM_CH_L, 0); // 左モータ出力を停止
+        if (pwmR == 0)
+                __HAL_TIM_SET_COMPARE(&MOTOR_TIM_HANDLER, MOTOR_TIM_CH_R, 0); // 右モータ出力を停止
 
 	if (pwmL != 0)
 	{
@@ -133,9 +133,9 @@ void getMotorCurrent(void)
 /////////////////////////////////////////////////////////////////////
 void MotorFanPwmOut(int16_t pwm)
 {
-	// 0除算回避
-	if (pwm == 0)
-		__HAL_TIM_SET_COMPARE(&MOTOR_TIM_HANDLER, MOTOR_SUCTION_TIM_CH, 0);
+        // PWM が 0 のとき比較レジスタを 0 に設定
+        if (pwm == 0)
+                __HAL_TIM_SET_COMPARE(&MOTOR_TIM_HANDLER, MOTOR_SUCTION_TIM_CH, 0); // 吸引モータ出力を停止
 
 	if (pwm != 0)
 	{


### PR DESCRIPTION
## 概要
- motorPwmOutとMotorFanPwmOutでPWMが0の場合に比較レジスタを0にする処理にコメントを追記
- 不要だった理由付けコメントを削除

## テスト
- `make test` (ターゲット 'test' が存在せず実行不可)
- `make` (Makefile が存在せず実行不可)


------
https://chatgpt.com/codex/tasks/task_e_68bc6fb11e4883239dc89e8c5182befe