### PR TITLE
motorPwmOutSynthのコメントにyrPwmとdPwmの説明を追加

### DIFF
--- a/robotrace_v2/Core/Src/motor.c
+++ b/robotrace_v2/Core/Src/motor.c
@@ -57,6 +57,8 @@ void motorPwmOut(int16_t pwmL, int16_t pwmR)
 // モジュール名 motorPwmOutSynth
 // 処理概要     トレースと速度制御のPID制御量をPWMとしてモータに出力する
 // 引数         tPwm: トレースのPID制御量 sPwm: 速度のPID制御量
+//              yrPwm: ヨーレートのPID制御量
+//              dPwm : 距離のPID制御量
 // 戻り値       なし
 ///////////////////////////////////////////////////////////////////////////
 void motorPwmOutSynth(int16_t tPwm, int16_t sPwm, int16_t yrPwm, int16_t dPwm)


### PR DESCRIPTION
## 概要
- motorPwmOutSynthのコメントにyrPwmとdPwmの制御内容を追記

## テスト
- `make` (Makefileが存在しないため失敗)


------
https://chatgpt.com/codex/tasks/task_e_68bc700a24b883238d71015e781dcd63