### PR TITLE
tPwm が 0 の場合の符号計算を回避

### DIFF
--- a/robotrace_v2/Core/Src/motor.c
+++ b/robotrace_v2/Core/Src/motor.c
@@ -69,13 +69,21 @@ void motorPwmOutSynth(int16_t tPwm, int16_t sPwm, int16_t yrPwm, int16_t dPwm)
 		overpwm = abs(sPwm) + abs(tPwm) - 1000; // 1000を超えた分の制御量を計算
 
 		// トレースの内輪側から越えた分の制御量を引く 正負はtPwmと同じ
-		if (tPwm > 0)
+		// tPwm が 0 の場合の 0 除算防止
+		if (tPwm != 0)
 		{
-			tracePwm = tPwm - (overpwm * (tPwm / abs(tPwm)));
+			if (tPwm > 0)
+			{
+				tracePwm = tPwm - (overpwm * (tPwm / abs(tPwm)));
+			}
+			else
+			{
+				tracePwm = tPwm + (overpwm * (tPwm / abs(tPwm)));
+			}
 		}
 		else
 		{
-			tracePwm = tPwm + (overpwm * (tPwm / abs(tPwm)));
+			tracePwm = tPwm;
 		}
 	}
 


### PR DESCRIPTION
## 概要
- `motorPwmOutSynth` 内の条件分岐にコメントを追加
- 追加した条件分岐のインデントを既存スタイル（タブ）に合わせて修正

## テスト
- `make test` を実行し、ターゲットが存在しないことを確認


------
https://chatgpt.com/codex/tasks/task_e_68bc6fb307a48323a7e79d2dfa11f608