### PR TITLE
MOTOR_AD_WINDOWの冪チェックをヘッダへ移動

### DIFF
--- a/robotrace_v2/Core/Inc/motor.h
+++ b/robotrace_v2/Core/Inc/motor.h
@@ -20,6 +20,11 @@
 #define RREF_R 1940.0F // 抵抗値
 
 #define MOTOR_AD_WINDOW 64
+// MOTOR_AD_WINDOW は2の冪である必要があるため、変更時は注意
+// ビット演算で2の冪かを静的に検証し、条件を満たさない場合はコンパイルエラー
+#if (MOTOR_AD_WINDOW & (MOTOR_AD_WINDOW - 1)) != 0
+#error "MOTOR_AD_WINDOW must be a power of two"
+#endif
 //====================================//
 // グローバル変数の宣言
 //====================================//

--- a/robotrace_v2/Core/Src/motor.c
+++ b/robotrace_v2/Core/Src/motor.c
@@ -2,6 +2,7 @@
 // インクルード
 //====================================//
 #include "motor.h"
+
 //====================================//
 // グローバル変数の宣言
 //====================================//
@@ -92,9 +93,11 @@ void motorPwmOutSynth(int16_t tPwm, int16_t sPwm, int16_t yrPwm, int16_t dPwm)
 ///////////////////////////////////////////////////////////////////////////
 void getMotorAD(uint16_t LAD, uint16_t RAD)
 {
-	motorCurrentADLInt[cntMotorAD & (MOTOR_AD_WINDOW - 1)] = LAD;
-	motorCurrentADRInt[cntMotorAD & (MOTOR_AD_WINDOW - 1)] = RAD;
-	cntMotorAD++;
+	// MOTOR_AD_WINDOW は2の冪であることを前提にインデックスをマスク
+	// 値を変更する場合はこの前提が崩れないよう注意する
+	motorCurrentADLInt[cntMotorAD & (MOTOR_AD_WINDOW - 1)] = LAD; // リングバッファに格納
+	motorCurrentADRInt[cntMotorAD & (MOTOR_AD_WINDOW - 1)] = RAD; // リングバッファに格納
+	cntMotorAD++; // 次回の格納位置を更新
 }
 ///////////////////////////////////////////////////////////////////////////
 // モジュール名 getMotorCurrent


### PR DESCRIPTION
## 概要
- MOTOR_AD_WINDOWが2の冪であることをmotor.hで静的に検証し、コメントを追記
- getMotorAD内のリングバッファ処理に説明コメントを追加し、インデントをタブに統一

## テスト
- `make` (Makefileが存在せず失敗)
- `gcc -std=c11 -c Core/Src/motor.c -I Core/Inc -I Drivers/STM32F4xx_HAL_Driver/Inc -I Drivers/CMSIS/Device/ST/STM32F4xx/Include -I Drivers/CMSIS/Include` (ターゲットデバイス未指定などの理由で失敗)


------
https://chatgpt.com/codex/tasks/task_e_68bc6fd79c40832380761f1a3ee9b9eb