### PR TITLE
ショートカット座標バッファ上限チェックとエラー処理を追加

### DIFF
--- a/robotrace_v2/Core/Src/courseAnalysis.c
+++ b/robotrace_v2/Core/Src/courseAnalysis.c
@@ -517,10 +517,20 @@ int16_t calcXYcies(int logNumber)
 			degzm /= SHORTCUTWINDOW;
 			if (distEnc - startEnc >= encMM(CALCDISTANCE_SHORTCUT))
 			{
-				shortCutxycie[indexSC].x = xm;
-				shortCutxycie[indexSC].y = ym;
-				startEnc = distEnc; // 距離計測開始位置を更新
-				indexSC++;
+				// バッファ上限に達していないか確認
+				if (indexSC < OPT_SHORT_BUFF_SIZE)
+				{
+					shortCutxycie[indexSC].x = xm;
+					shortCutxycie[indexSC].y = ym;
+					startEnc = distEnc; // 距離計測開始位置を更新
+					indexSC++; // バッファの次の位置へ
+				}
+				else
+				{
+					// 上限超過: エラー番号-7を設定しループを終了
+					ret = -7;
+					break;
+				}
 			}
 
 			i++;


### PR DESCRIPTION
## 概要
- calcXYcies 内で shortCutxycie への書き込み前にバッファ上限を確認
- 上限超過時にエラー番号 -7 を設定しループを終了
- バッファ進行処理にコメントを追加

## テスト
- `gcc -fsyntax-only -DSTM32F446xx -Irobotrace_v2/Core/Inc -Irobotrace_v2/Drivers/STM32F4xx_HAL_Driver/Inc -Irobotrace_v2/Drivers/CMSIS/Include -Irobotrace_v2/Drivers/CMSIS/Device/ST/STM32F4xx/Include robotrace_v2/Core/Src/courseAnalysis.c 2>&1 | tail -n 20` *(エラー: `_ansi.h` が見つからない)*

------
https://chatgpt.com/codex/tasks/task_e_68bd1f5de1e48323a02b85a42cc86616