### PR TITLE
calcXYciesのループ条件を修正

### DIFF
--- a/robotrace_v2/Core/Src/courseAnalysis.c
+++ b/robotrace_v2/Core/Src/courseAnalysis.c
@@ -535,7 +535,7 @@ int16_t calcXYcies(int logNumber)
 		// plotファイルに初期値記録
 		f_printf(&fil_Plot, "%d,%d,%d\n", (int32_t)(shortCutxycie[0].x * 10000), (int32_t)(shortCutxycie[0].y * 10000), (int32_t)(shortCutxycie[0].w * 10000));
 
-		for (i = 1; i <= indexSC; i++)
+		for (i = 1; i < indexSC; i++) // 配列の範囲外アクセスを防ぐ
 		{
 			xe = shortCutxycie[i].x - shortCutxycie[i - 1].x; // x座標の移動量
 			ye = shortCutxycie[i].y - shortCutxycie[i - 1].y; // y座標の移動量


### PR DESCRIPTION
## 概要
- calcXYcies内のループ条件を`i < indexSC`へ変更し、配列アクセスの安全性を確保
- ループ行のコメントを既存スタイルに合わせて調整

## テスト
- `gcc -c robotrace_v2/Core/Src/courseAnalysis.c -Irobotrace_v2/Core/Inc` : `stm32f4xx_hal.h` がなくビルド不可

------
https://chatgpt.com/codex/tasks/task_e_68bd1f5e69688323bf19f0fa859e9079