### PR TITLE
calcXYciesでsnprintfのエラー番号を-8に変更

### DIFF
--- a/robotrace_v2/Core/Src/courseAnalysis.c
+++ b/robotrace_v2/Core/Src/courseAnalysis.c
@@ -555,15 +555,24 @@ int16_t calcXYcies(int logNumber)
 			degz += thetae;
 
 			shortCutxycie[i].w = degz; // yaw軸角度
-
-			// plotファイルに書き込み
-			sprintf(plotStr,"%f,%f,%f\n",shortCutxycie[i].x,shortCutxycie[i].y,shortCutxycie[i].w);
-			f_puts(plotStr, &fil_Plot);
+				// plotファイルに書き込み
+				int snlen = snprintf((char *)plotStr, sizeof(plotStr), "%f,%f,%f\n", shortCutxycie[i].x, shortCutxycie[i].y, shortCutxycie[i].w); // 戻り値で書き込み長を確認
+				if (snlen < 0 || snlen >= sizeof(plotStr))
+{
+					// snprintfが失敗した場合やバッファが不足した場合はエラー番号-8を設定して処理を中断する
+					ret = -8;
+					break;
+			}
+				f_puts((TCHAR *)plotStr, &fil_Plot);
 			
 			thetaBefore = theta; // 前回のyaw軸角度を更新
 		}
 
-		ret = indexSC;
+			if (ret >= 0)
+			{
+				// ループ内でエラーがなければ解析した要素数を返す
+				ret = indexSC;
+			}
 	}
 	else
 	{


### PR DESCRIPTION
## 概要
- snprintfの戻り値を確認し、エラー時に-8を返すよう修正
- エラー処理にコメントを追記し、戻り値のチェックを明確化

## テスト
- `gcc -fsyntax-only -Irobotrace_v2/Core/Inc -Irobotrace_v2 -Irobotrace_v2/FATFS/Target -Irobotrace_v2/Drivers/STM32F4xx_HAL_Driver/Inc -Irobotrace_v2/Drivers/CMSIS/Device/ST/STM32F4xx/Include -Irobotrace_v2/Drivers/CMSIS/Include robotrace_v2/Core/Src/courseAnalysis.c` （`_ansi.h`が見つからず失敗）

------
https://chatgpt.com/codex/tasks/task_e_68bd1f5fbc848323806e8095e479fdca