### PR TITLE
エラー時のログ番号保存とフラグ設定を条件化

### DIFF
--- a/robotrace_v2/Core/Src/courseAnalysis.c
+++ b/robotrace_v2/Core/Src/courseAnalysis.c
@@ -604,12 +604,16 @@ int16_t calcXYcies(int logNumber)
 	f_close(&fil_Read);
 	f_close(&fil_Plot);
 
-	// 解析済みのログ番号を保存
-	saveLogNumber(logNumber);
-	analizedNumber = logNumber;
+	// エラー時にはログ番号保存やフラグ設定をスキップする
+	if (ret >= 0)
+	{
+		// 解析済みのログ番号を保存
+		saveLogNumber(logNumber);
+		analizedNumber = logNumber;
 
-	// 2次走行フラグ 距離基準2次走行
-	optimalTrace = BOOST_SHORTCUT;
+		// 2次走行フラグ 距離基準2次走行
+		optimalTrace = BOOST_SHORTCUT;
+	}
 
 	return ret;
 }


### PR DESCRIPTION
## 概要
- ログ解析後の後処理を `ret >= 0` の場合のみ実行するように変更
- エラー発生時はログ番号保存やフラグ設定をスキップする旨をコメントで明示

## テスト
- `make` (Makefile が存在せず失敗)

------
https://chatgpt.com/codex/tasks/task_e_68bd793bbeb8832383e701008198ff38