### PR TITLE
ラインセンサのキャリブレーション機能を強化

### DIFF
--- a/robotrace_v2/Core/Inc/lineSensor.h
+++ b/robotrace_v2/Core/Inc/lineSensor.h
@@ -25,7 +25,8 @@ extern float angleSensor;
 extern bool lineSensorState;
 
 extern uint16_t lSensorCari[NUM_SENSORS];
-extern uint16_t lSensorOffset[NUM_SENSORS];
+extern uint16_t lSensorMax[NUM_SENSORS];	// 各センサの最大値
+extern uint16_t lSensorMin[NUM_SENSORS];	// 各センサの最小値
 extern uint8_t modeCalLinesensors;
 
 //====================================//

--- a/robotrace_v2/Core/Src/PIDcontrol.c
+++ b/robotrace_v2/Core/Src/PIDcontrol.c
@@ -71,11 +71,11 @@ void motorControlTrace(void)
 	static int32_t traceBefore;
 
 	// サーボモータ用PWM値計算
-        if (lSensorMax[0] > lSensorMin[0])
-        {
-                senL = (lSensorCari[4]) + (lSensorCari[3] * 0.7) + (lSensorCari[2] * 0.5) + (lSensorCari[1] * 0.3) + (lSensorCari[0] * 0.2);
-                senR = (lSensorCari[5]) + (lSensorCari[6] * 0.7) + (lSensorCari[7] * 0.5) + (lSensorCari[8] * 0.3) + (lSensorCari[9] * 0.2);
-        }
+	if (lSensorMax[0] > lSensorMin[0])
+	{
+		senL = (lSensorCari[4]) + (lSensorCari[3] * 0.7) + (lSensorCari[2] * 0.5) + (lSensorCari[1] * 0.3) + (lSensorCari[0] * 0.2);
+		senR = (lSensorCari[5]) + (lSensorCari[6] * 0.7) + (lSensorCari[7] * 0.5) + (lSensorCari[8] * 0.3) + (lSensorCari[9] * 0.2);
+	}
 	else
 	{
 		// senL = (lSensor[4]) + (lSensor[3]*0.8) + (lSensor[2]*0.7) + (lSensor[1]*0.5) + (lSensor[0]*0.3);

--- a/robotrace_v2/Core/Src/PIDcontrol.c
+++ b/robotrace_v2/Core/Src/PIDcontrol.c
@@ -71,11 +71,11 @@ void motorControlTrace(void)
 	static int32_t traceBefore;
 
 	// サーボモータ用PWM値計算
-	if (lSensorOffset[0] > 0)
-	{
-		senL = (lSensorCari[4]) + (lSensorCari[3] * 0.7) + (lSensorCari[2] * 0.5) + (lSensorCari[1] * 0.3) + (lSensorCari[0] * 0.2);
-		senR = (lSensorCari[5]) + (lSensorCari[6] * 0.7) + (lSensorCari[7] * 0.5) + (lSensorCari[8] * 0.3) + (lSensorCari[9] * 0.2);
-	}
+        if (lSensorMax[0] > lSensorMin[0])
+        {
+                senL = (lSensorCari[4]) + (lSensorCari[3] * 0.7) + (lSensorCari[2] * 0.5) + (lSensorCari[1] * 0.3) + (lSensorCari[0] * 0.2);
+                senR = (lSensorCari[5]) + (lSensorCari[6] * 0.7) + (lSensorCari[7] * 0.5) + (lSensorCari[8] * 0.3) + (lSensorCari[9] * 0.2);
+        }
 	else
 	{
 		// senL = (lSensor[4]) + (lSensor[3]*0.8) + (lSensor[2]*0.7) + (lSensor[1]*0.5) + (lSensor[0]*0.3);

--- a/robotrace_v2/Core/Src/control.c
+++ b/robotrace_v2/Core/Src/control.c
@@ -141,7 +141,7 @@ void initSystem(void)
 			readPIDparameters(&yawCtrl);
 			readPIDparameters(&distCtrl);
 
-                    readLinesenval(); // ラインセンサの最大値と最小値を取得
+            readLinesenval(); // ラインセンサの最大値と最小値を取得
 			readTgtspeeds();  // 目標速度を取得
 
 			if (modeDSP)

--- a/robotrace_v2/Core/Src/control.c
+++ b/robotrace_v2/Core/Src/control.c
@@ -141,7 +141,7 @@ void initSystem(void)
 			readPIDparameters(&yawCtrl);
 			readPIDparameters(&distCtrl);
 
-			readLinesenval(); // ラインセンサオフセット値を取得
+                    readLinesenval(); // ラインセンサの最大値と最小値を取得
 			readTgtspeeds();  // 目標速度を取得
 
 			if (modeDSP)

--- a/robotrace_v2/Core/Src/lineSensor.c
+++ b/robotrace_v2/Core/Src/lineSensor.c
@@ -178,18 +178,17 @@ void writeLinesenval(void)
 
 	if (fresult == FR_OK)
 	{
-			// 最大値を保存
-			for (i = 0; i < NUM_SENSORS; i++)
-			{
-				sprintf(str, "%04d,", lSensorMax[i]);
-				f_puts(str, &fil);
-			}
-			// 最小値を保存
-			for (i = 0; i < NUM_SENSORS; i++)
-			{
-				sprintf(str, "%04d,", lSensorMin[i]);
-				f_puts(str, &fil);
-			}
+		// 最大値を保存
+		for (i = 0; i < NUM_SENSORS; i++)
+		{
+			sprintf(str, "%04d,", lSensorMax[i]);
+			f_puts(str, &fil);
+		}
+		// 最小値を保存
+		for (i = 0; i < NUM_SENSORS; i++)
+		{
+			sprintf(str, "%04d,", lSensorMin[i]);
+			f_puts(str, &fil);
 		}
 	}
 
@@ -216,18 +215,17 @@ void readLinesenval(void)
 
 	if (fresult == FR_OK)
 	{
-			// 最大値を読み込む
-			for (i = 0; i < NUM_SENSORS; i++)
-			{
-				f_gets(str, 6, &fil);
-				sscanf(str, "%hu,", &lSensorMax[i]);
-			}
-			// 最小値を読み込む
-			for (i = 0; i < NUM_SENSORS; i++)
-			{
-				f_gets(str, 6, &fil);
-				sscanf(str, "%hu,", &lSensorMin[i]);
-			}
+		// 最大値を読み込む
+		for (i = 0; i < NUM_SENSORS; i++)
+		{
+			f_gets(str, 6, &fil);
+			sscanf(str, "%hu,", &lSensorMax[i]);
+		}
+		// 最小値を読み込む
+		for (i = 0; i < NUM_SENSORS; i++)
+		{
+			f_gets(str, 6, &fil);
+			sscanf(str, "%hu,", &lSensorMin[i]);
 		}
 	}
 

--- a/robotrace_v2/Core/Src/lineSensor.c
+++ b/robotrace_v2/Core/Src/lineSensor.c
@@ -16,7 +16,8 @@ bool lineSensorState = false;			 // true:ラインセンサ点灯 false:ライ�
 uint16_t lineIndex = 0;
 float angleSensor;
 // キャリブレーション関連
-uint16_t lSensorOffset[NUM_SENSORS] = {0};
+uint16_t lSensorMax[NUM_SENSORS] = {0};	// 各センサの最大値
+uint16_t lSensorMin[NUM_SENSORS] = {[0 ... NUM_SENSORS - 1] = UINT16_MAX};	// 各センサの最小値
 uint8_t modeCalLinesensors = 0;
 /////////////////////////////////////////////////////////////////////
 // モジュール名 powerLineSensors
@@ -58,19 +59,27 @@ void getLineSensor(void)
 		{
 			lSensor[i] = lSensorInt[i] >> 4; // 平均値算出
 			lSensorInt[i] = 0;				 // 積算値リセット
-
-			// キャリブレーション済みの場合
-			if (lSensorOffset[i] > 0 && modeCalLinesensors == 0)
+			// 最大値・最小値を更新
+			if (modeCalLinesensors == 1)
 			{
-				lSensorCari[i] = (uint16_t)(BASEVAL * (float)lSensor[i] / (float)lSensorOffset[i]);
-			}
-			// キャリブレーション中
-			if (lineSensorState && modeCalLinesensors == 1)
-			{
-				if (lSensor[i] > lSensorOffset[i])
+				if (lSensor[i] > lSensorMax[i])
 				{
-					lSensorOffset[i] = lSensor[i];
+					lSensorMax[i] = lSensor[i];	// 最大値更新
 				}
+				if (lSensor[i] < lSensorMin[i])
+				{
+					lSensorMin[i] = lSensor[i];	// 最小値更新
+				}
+			}
+			// 正規化計算
+			uint16_t range = lSensorMax[i] - lSensorMin[i];
+			if (range != 0)
+			{
+				lSensorCari[i] = (uint16_t)((lSensor[i] - lSensorMin[i]) * BASEVAL / range);
+			}
+			else
+			{
+				lSensorCari[i] = 0;	// 分母ゼロ対策
 			}
 		}
 	}
@@ -137,18 +146,21 @@ void getAngleSensor(void)
 void calibrationLinesensor(void)
 {
 	uint8_t i;
-
 	for (i = 0; i < NUM_SENSORS; i++)
 	{
-		if (lSensor[i] > lSensorOffset[i])
+		if (lSensor[i] > lSensorMax[i])
 		{
-			lSensorOffset[i] = lSensor[i];
+			lSensorMax[i] = lSensor[i];	// 最大値更新
+		}
+		if (lSensor[i] < lSensorMin[i])
+		{
+			lSensorMin[i] = lSensor[i];	// 最小値更新
 		}
 	}
 }
 ///////////////////////////////////////////////////////////////////////////
 // モジュール名 writeLinesenval
-// 処理概要     ラインセンサの最大値をSDカードに書き込む
+// 処理概要     ラインセンサの最大値と最小値をSDカードに書き込む
 // 引数         なし
 // 戻り値       なし
 ///////////////////////////////////////////////////////////////////////////
@@ -166,10 +178,18 @@ void writeLinesenval(void)
 
 	if (fresult == FR_OK)
 	{
-		for (i = 0; i < NUM_SENSORS; i++)
-		{
-			sprintf(str, "%04d,", lSensorOffset[i]);
-			f_puts(str, &fil);
+			// 最大値を保存
+			for (i = 0; i < NUM_SENSORS; i++)
+			{
+				sprintf(str, "%04d,", lSensorMax[i]);
+				f_puts(str, &fil);
+			}
+			// 最小値を保存
+			for (i = 0; i < NUM_SENSORS; i++)
+			{
+				sprintf(str, "%04d,", lSensorMin[i]);
+				f_puts(str, &fil);
+			}
 		}
 	}
 
@@ -177,7 +197,7 @@ void writeLinesenval(void)
 }
 ///////////////////////////////////////////////////////////////////////////
 // モジュール名 readLinesenval
-// 処理概要     ラインセンサの最大値をSDカードから読み取る
+// 処理概要     ラインセンサの最大値と最小値をSDカードから読み取る
 // 引数         なし
 // 戻り値       なし
 ///////////////////////////////////////////////////////////////////////////
@@ -196,10 +216,18 @@ void readLinesenval(void)
 
 	if (fresult == FR_OK)
 	{
-		for (i = 0; i < NUM_SENSORS; i++)
-		{
-			f_gets(str, 6, &fil);				   // 文字列取得 カンマ含む
-			sscanf(str, "%d,", &lSensorOffset[i]); // 文字列→数値
+			// 最大値を読み込む
+			for (i = 0; i < NUM_SENSORS; i++)
+			{
+				f_gets(str, 6, &fil);
+				sscanf(str, "%hu,", &lSensorMax[i]);
+			}
+			// 最小値を読み込む
+			for (i = 0; i < NUM_SENSORS; i++)
+			{
+				f_gets(str, 6, &fil);
+				sscanf(str, "%hu,", &lSensorMin[i]);
+			}
 		}
 	}
 

--- a/robotrace_v2/Core/Src/setup.c
+++ b/robotrace_v2/Core/Src/setup.c
@@ -844,32 +844,32 @@ static void setup_calibration(void)
 	}
 	case 2: // 開始準備
 	{
-               if (setupTimer.cntSetup1 > 1000) // 一定時間待機
-               {
-                       uint8_t i;
-	ssd1306_FillRectangle(0, 15, 127, 63, Black); // メイン表示空白埋め
-	ssd1306_SetCursor(22, 28);
-	ssd1306_printf(Font_7x10, "Calibration");
-	ssd1306_SetCursor(53, 42);
-	ssd1306_printf(Font_7x10, "Now");
-	ssd1306_UpdateScreen(); // グラフィック液晶更新
+		if (setupTimer.cntSetup1 > 1000) // 一定時間待機
+		{
+			uint8_t i;
+			ssd1306_FillRectangle(0, 15, 127, 63, Black); // メイン表示空白埋め
+			ssd1306_SetCursor(22, 28);
+			ssd1306_printf(Font_7x10, "Calibration");
+			ssd1306_SetCursor(53, 42);
+			ssd1306_printf(Font_7x10, "Now");
+			ssd1306_UpdateScreen(); // グラフィック液晶更新
 
-                       // 配列初期化
-                       for (i = 0; i < NUM_SENSORS; i++)
-                       {
-                               lSensorMax[i] = 0;            // 最大値初期化
-                               lSensorMin[i] = UINT16_MAX;   // 最小値初期化
-                       }
+			// 配列初期化
+			for (i = 0; i < NUM_SENSORS; i++)
+			{
+				lSensorMax[i] = 0;            // 最大値初期化
+				lSensorMin[i] = UINT16_MAX;   // 最小値初期化
+			}
 
-                       powerLineSensors(1);    // ラインセンサ点灯
-                       modeCalLinesensors = 1; // キャリブレーション開始
+			powerLineSensors(1);    // ラインセンサ点灯
+			modeCalLinesensors = 1; // キャリブレーション開始
 
-                       // 手動で機体を動かしキャリブレーションする
+			// 手動で機体を動かしキャリブレーションする
 
-                       pattern.calibration = 3; // 次のステップへ
-               }
-               break;
-       }
+			pattern.calibration = 3; // 次のステップへ
+		}
+		break;
+    }
 	case 3: // スイッチ押下で終了
 	{
 		data_select(&testFlags.trace_test, SW_PUSH); // SW_PUSH入力を監視
@@ -1121,31 +1121,31 @@ static void setup_start(void)
 		// 停止状態を維持
 		setTargetSpeed(0);
 
-                if (swValTact == SW_PUSH)
-                {
-                        if (lSensorMax[0] > lSensorMin[0])
-                        {
-                                // キャリブレーション実施済み
-                                setupFlags.start = 1;
-                        }
-                        else
-                        {
-                                pattern.calibration = 2;
-                        }
-                }
-                else if (swValTact == SW_RIGHT)
-                {
-                        // オートスタート
-                        if (lSensorMax[0] > lSensorMin[0])
-                        {
-                                // キャリブレーション実施済み
-                                autoStart = 1;
-                        }
-                        else
-                        {
-                                pattern.calibration = 2;
-                        }
-                }
+		if (swValTact == SW_PUSH)
+		{
+			if (lSensorMax[0] > lSensorMin[0])
+			{
+				// キャリブレーション実施済み
+				setupFlags.start = 1;
+			}
+			else
+			{
+				pattern.calibration = 2;
+			}
+		}
+		else if (swValTact == SW_RIGHT)
+		{
+			// オートスタート
+			if (lSensorMax[0] > lSensorMin[0])
+			{
+				// キャリブレーション実施済み
+				autoStart = 1;
+			}
+			else
+			{
+				pattern.calibration = 2;
+			}
+		}
 		break;
 	}
 	case 2: // キャリブレーション未実施
@@ -1647,7 +1647,7 @@ void setupNonDisp(void)
 				mode = START_OPTIMAL;
 			}
 			veloCtrl.Int = 0; // I成分リセット
-                  if (lSensorMax[0] > lSensorMin[0])
+            if (lSensorMax[0] > lSensorMin[0])
 			{
 				// キャリブレーション実施済み
 				setupFlags.start = 1;

--- a/robotrace_v2/Core/Src/setup.c
+++ b/robotrace_v2/Core/Src/setup.c
@@ -394,54 +394,27 @@ static void test_linesensor(void)
 		testFlags.motor_test = 0;
 	}
 
-	if (lSensorOffset[0] > 0 && modeCalLinesensors == 0)
-	{
-		ssd1306_SetCursor(37, 22);
-		ssd1306_printf(Font_6x8, "%4d", lSensorCari[4]);
-		ssd1306_SetCursor(31, 30);
-		ssd1306_printf(Font_6x8, "%4d", lSensorCari[3]);
-		ssd1306_SetCursor(22, 38);
-		ssd1306_printf(Font_6x8, "%4d", lSensorCari[2]);
-		ssd1306_SetCursor(13, 46);
-		ssd1306_printf(Font_6x8, "%4d", lSensorCari[1]);
-		ssd1306_SetCursor(6, 54);
-		ssd1306_printf(Font_6x8, "%4d", lSensorCari[0]);
+	ssd1306_SetCursor(37, 22);
+	ssd1306_printf(Font_6x8, "%4d", lSensorCari[4]);
+	ssd1306_SetCursor(31, 30);
+	ssd1306_printf(Font_6x8, "%4d", lSensorCari[3]);
+	ssd1306_SetCursor(22, 38);
+	ssd1306_printf(Font_6x8, "%4d", lSensorCari[2]);
+	ssd1306_SetCursor(13, 46);
+	ssd1306_printf(Font_6x8, "%4d", lSensorCari[1]);
+	ssd1306_SetCursor(6, 54);
+	ssd1306_printf(Font_6x8, "%4d", lSensorCari[0]);
 
-		ssd1306_SetCursor(65, 22);
-		ssd1306_printf(Font_6x8, "%4d", lSensorCari[5]);
-		ssd1306_SetCursor(71, 30);
-		ssd1306_printf(Font_6x8, "%4d", lSensorCari[6]);
-		ssd1306_SetCursor(80, 38);
-		ssd1306_printf(Font_6x8, "%4d", lSensorCari[7]);
-		ssd1306_SetCursor(89, 46);
-		ssd1306_printf(Font_6x8, "%4d", lSensorCari[8]);
-		ssd1306_SetCursor(95, 54);
-		ssd1306_printf(Font_6x8, "%4d", lSensorCari[9]);
-	}
-	else
-	{
-		ssd1306_SetCursor(37, 22);
-		ssd1306_printf(Font_6x8, "%4d", lSensor[4]);
-		ssd1306_SetCursor(31, 30);
-		ssd1306_printf(Font_6x8, "%4d", lSensor[3]);
-		ssd1306_SetCursor(22, 38);
-		ssd1306_printf(Font_6x8, "%4d", lSensor[2]);
-		ssd1306_SetCursor(13, 46);
-		ssd1306_printf(Font_6x8, "%4d", lSensor[1]);
-		ssd1306_SetCursor(6, 54);
-		ssd1306_printf(Font_6x8, "%4d", lSensor[0]);
-
-		ssd1306_SetCursor(65, 22);
-		ssd1306_printf(Font_6x8, "%4d", lSensor[5]);
-		ssd1306_SetCursor(71, 30);
-		ssd1306_printf(Font_6x8, "%4d", lSensor[6]);
-		ssd1306_SetCursor(80, 38);
-		ssd1306_printf(Font_6x8, "%4d", lSensor[7]);
-		ssd1306_SetCursor(89, 46);
-		ssd1306_printf(Font_6x8, "%4d", lSensor[8]);
-		ssd1306_SetCursor(95, 54);
-		ssd1306_printf(Font_6x8, "%4d", lSensor[9]);
-	}
+	ssd1306_SetCursor(65, 22);
+	ssd1306_printf(Font_6x8, "%4d", lSensorCari[5]);
+	ssd1306_SetCursor(71, 30);
+	ssd1306_printf(Font_6x8, "%4d", lSensorCari[6]);
+	ssd1306_SetCursor(80, 38);
+	ssd1306_printf(Font_6x8, "%4d", lSensorCari[7]);
+	ssd1306_SetCursor(89, 46);
+	ssd1306_printf(Font_6x8, "%4d", lSensorCari[8]);
+	ssd1306_SetCursor(95, 54);
+	ssd1306_printf(Font_6x8, "%4d", lSensorCari[9]);
 
 	data_select(&testFlags.motor_test, SW_PUSH);
 	if (testFlags.motor_test == 1)
@@ -859,7 +832,7 @@ static void setup_calibration(void)
 	{
 		setTargetSpeed(0); // 速度をゼロに設定
 		ssd1306_SetCursor(65, 22);
-		ssd1306_printf(Font_6x8, "%4d", lSensorOffset[0]);
+	ssd1306_printf(Font_6x8, "%4d", lSensorCari[0]);
 
 		data_select(&testFlags.trace_test, SW_PUSH); // SW_PUSH入力を監視
 		if (testFlags.trace_test)
@@ -871,27 +844,32 @@ static void setup_calibration(void)
 	}
 	case 2: // 開始準備
 	{
-		if (setupTimer.cntSetup1 > 1000) // 一定時間待機
-		{
-			ssd1306_FillRectangle(0, 15, 127, 63, Black); // メイン表示空白埋め
-			ssd1306_SetCursor(22, 28);
-			ssd1306_printf(Font_7x10, "Calibration");
-			ssd1306_SetCursor(53, 42);
-			ssd1306_printf(Font_7x10, "Now");
-			ssd1306_UpdateScreen(); // グラフィック液晶更新
+               if (setupTimer.cntSetup1 > 1000) // 一定時間待機
+               {
+                       uint8_t i;
+	ssd1306_FillRectangle(0, 15, 127, 63, Black); // メイン表示空白埋め
+	ssd1306_SetCursor(22, 28);
+	ssd1306_printf(Font_7x10, "Calibration");
+	ssd1306_SetCursor(53, 42);
+	ssd1306_printf(Font_7x10, "Now");
+	ssd1306_UpdateScreen(); // グラフィック液晶更新
 
-			// 配列初期化
-			memset(&lSensorOffset, 0, sizeof(uint16_t) * NUM_SENSORS);
+                       // 配列初期化
+                       for (i = 0; i < NUM_SENSORS; i++)
+                       {
+                               lSensorMax[i] = 0;            // 最大値初期化
+                               lSensorMin[i] = UINT16_MAX;   // 最小値初期化
+                       }
 
-			powerLineSensors(1);    // ラインセンサ点灯
-			modeCalLinesensors = 1; // キャリブレーション開始
+                       powerLineSensors(1);    // ラインセンサ点灯
+                       modeCalLinesensors = 1; // キャリブレーション開始
 
-			// 手動で機体を動かしキャリブレーションする
+                       // 手動で機体を動かしキャリブレーションする
 
-			pattern.calibration = 3; // 次のステップへ
-		}
-		break;
-	}
+                       pattern.calibration = 3; // 次のステップへ
+               }
+               break;
+       }
 	case 3: // スイッチ押下で終了
 	{
 		data_select(&testFlags.trace_test, SW_PUSH); // SW_PUSH入力を監視
@@ -1143,31 +1121,31 @@ static void setup_start(void)
 		// 停止状態を維持
 		setTargetSpeed(0);
 
-		if (swValTact == SW_PUSH)
-		{
-			if (lSensorOffset[0] > 0)
-			{
-				// キャリブレーション実施済み
-				setupFlags.start = 1;
-			}
-			else
-			{
-				pattern.calibration = 2;
-			}
-		}
-		else if (swValTact == SW_RIGHT)
-		{
-			// オートスタート
-			if (lSensorOffset[0] > 0)
-			{
-				// キャリブレーション実施済み
-				autoStart = 1;
-			}
-			else
-			{
-				pattern.calibration = 2;
-			}
-		}
+                if (swValTact == SW_PUSH)
+                {
+                        if (lSensorMax[0] > lSensorMin[0])
+                        {
+                                // キャリブレーション実施済み
+                                setupFlags.start = 1;
+                        }
+                        else
+                        {
+                                pattern.calibration = 2;
+                        }
+                }
+                else if (swValTact == SW_RIGHT)
+                {
+                        // オートスタート
+                        if (lSensorMax[0] > lSensorMin[0])
+                        {
+                                // キャリブレーション実施済み
+                                autoStart = 1;
+                        }
+                        else
+                        {
+                                pattern.calibration = 2;
+                        }
+                }
 		break;
 	}
 	case 2: // キャリブレーション未実施
@@ -1669,7 +1647,7 @@ void setupNonDisp(void)
 				mode = START_OPTIMAL;
 			}
 			veloCtrl.Int = 0; // I成分リセット
-			if (lSensorOffset[0] > 0)
+                  if (lSensorMax[0] > lSensorMin[0])
 			{
 				// キャリブレーション実施済み
 				setupFlags.start = 1;


### PR DESCRIPTION
## 概要
- ラインセンサの最大値・最小値を保持する配列を追加
- キャリブレーション処理と正規化計算を更新
- SDカードへの保存フォーマットを最大値/最小値対応に変更

## テスト
- `make` (Makefileが存在せずビルド不可)

------
https://chatgpt.com/codex/tasks/task_e_68c51bb4119083239d15c132ce119cae