### PR TITLE
motorControlTraceのDevログ機能追加

### DIFF
--- a/robotrace_v2/Core/Inc/PIDcontrol.h
+++ b/robotrace_v2/Core/Inc/PIDcontrol.h
@@ -46,6 +46,7 @@ extern uint8_t	targetSpeed;	// 目標速度
 extern float 	targetAngle;    // 目標角度
 extern float    targetAngularVelocity;  // 目標角速度
 extern int16_t  targetDist;		        // 目標X座標
+extern int16_t	 traceDev;			// ライントレース偏差(SDログ用)
 
 extern pidParam lineTraceCtrl;
 extern pidParam veloCtrl;

--- a/robotrace_v2/Core/Inc/SDcard.h
+++ b/robotrace_v2/Core/Inc/SDcard.h
@@ -13,7 +13,7 @@
 #ifdef LOG_RUNNING_WRITE
 #define BUFFER_SIZE_LOG 512
 #define LOG_NUM_8BIT 3
-#define LOG_NUM_16BIT 5
+#define LOG_NUM_16BIT 6 // traceDev追加
 #define LOG_NUM_32BIT 1
 #define LOG_NUM_FLOAT 1
 #define LOG_SIZE (LOG_NUM_8BIT * sizeof(uint8_t)) + (LOG_NUM_16BIT * sizeof(uint16_t)) + (LOG_NUM_32BIT * sizeof(uint32_t)) + (LOG_NUM_FLOAT * sizeof(float))

--- a/robotrace_v2/Core/Src/PIDcontrol.c
+++ b/robotrace_v2/Core/Src/PIDcontrol.c
@@ -16,6 +16,7 @@ uint8_t targetSpeed;		 // 目標速度
 float targetAngle;			 // 目標角速度
 float targetAngularVelocity; // 目標角度
 int16_t targetDist;			 // 目標X座標
+	int16_t traceDev;			// ライントレース偏差(SDログ用)
 
 ///////////////////////////////////////////////////////////////////////////
 // モジュール名 setTargetSpeed
@@ -84,6 +85,7 @@ void motorControlTrace(void)
 		senR = (lSensor[6]);
 	}
 	Dev = senL - senR;
+	traceDev = (int16_t)Dev;	// SDログ用に偏差を保持
 
 	// I成分積算
 	lineTraceCtrl.Int += (float)Dev * 0.001;

--- a/robotrace_v2/Core/Src/SDcard.c
+++ b/robotrace_v2/Core/Src/SDcard.c
@@ -211,6 +211,7 @@ void createLog(void)
 	// setLogStr("CurrentR", "%f");
 	setLogStr("lineTraceCtrl", "%d");
 	setLogStr("veloCtrl", "%d");
+	setLogStr("traceDev", "%d");	// Devのログ追加
 
 	setLogStr("x", "%f");
 	setLogStr("y", "%f");
@@ -558,10 +559,11 @@ void endLog(void)
 			logval16[2],	// optimalIndex
 			// (int16_t)logval16[3],		// motorpwmL
 			// (int16_t)logval16[4],		// motorpwmR
-			// (float)logval16[5] / 10000,	// CurrentL
-			// (float)logval16[6] / 10000,	// CurrentR
+			// (float)logval16[6] / 10000,	// CurrentL
+			// (float)logval16[7] / 10000,	// CurrentR
 			(int16_t)logval16[3],		// lineTraceCtrl
 			(int16_t)logval16[4],		// veloCtrl
+			(int16_t)logval16[5],		// traceDev
 			logvalf[2],		// x
 			logvalf[3]		// y
 		);

--- a/robotrace_v2/Core/Src/timer.c
+++ b/robotrace_v2/Core/Src/timer.c
@@ -131,6 +131,7 @@ void Interrupt1ms(void)
 					// (int16_t)(motorCurrentR * 10000),
 					lineTraceCtrl.pwm,
 					veloCtrl.pwm,
+					traceDev,		// Dev偏差
 					// 32bit
 					encTotalOptimal,
 					// float型


### PR DESCRIPTION
## 概要
- motorControlTraceで算出した偏差をグローバル変数に保持
- 偏差をSDカードのログに追加

## テスト
- `make 2>&1 | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68c53ca42e208323b593fdbff9cda4f7