### PR TITLE
センサ重み係数をマクロ化

### DIFF
--- a/robotrace_v2/Core/Inc/PIDcontrol.h
+++ b/robotrace_v2/Core/Inc/PIDcontrol.h
@@ -14,6 +14,13 @@
 #define KI1		0
 #define KD1		100
 
+// ライントレース用センサ重み係数（中央から外側に向かって適用）
+#define TRACE_WEIGHT_CENTER		1.0f
+#define TRACE_WEIGHT_INNER		0.9f
+#define TRACE_WEIGHT_MIDDLE		0.8f
+#define TRACE_WEIGHT_OUTER		0.7f
+#define TRACE_WEIGHT_FAR		0.5f
+
 #define KP2		15
 #define KI2		100
 #define KD2		0

--- a/robotrace_v2/Core/Src/PIDcontrol.c
+++ b/robotrace_v2/Core/Src/PIDcontrol.c
@@ -73,8 +73,9 @@ void motorControlTrace(void)
 	// サーボモータ用PWM値計算
 	if (lSensorMax[0] > lSensorMin[0])
 	{
-		senL = (lSensorCari[4]) + (lSensorCari[3] * 0.9) + (lSensorCari[2] * 0.8) + (lSensorCari[1] * 0.7) + (lSensorCari[0] * 0.5);
-		senR = (lSensorCari[5]) + (lSensorCari[6] * 0.9) + (lSensorCari[7] * 0.8) + (lSensorCari[8] * 0.7) + (lSensorCari[9] * 0.5);
+		// マクロで設定した重みを掛け合わせてセンサ値を合成
+		senL = (lSensorCari[4] * TRACE_WEIGHT_CENTER) + (lSensorCari[3] * TRACE_WEIGHT_INNER) + (lSensorCari[2] * TRACE_WEIGHT_MIDDLE) + (lSensorCari[1] * TRACE_WEIGHT_OUTER) + (lSensorCari[0] * TRACE_WEIGHT_FAR);
+		senR = (lSensorCari[5] * TRACE_WEIGHT_CENTER) + (lSensorCari[6] * TRACE_WEIGHT_INNER) + (lSensorCari[7] * TRACE_WEIGHT_MIDDLE) + (lSensorCari[8] * TRACE_WEIGHT_OUTER) + (lSensorCari[9] * TRACE_WEIGHT_FAR);
 	}
 	else
 	{


### PR DESCRIPTION
## 概要
- ライントレース用センサの重み係数をマクロとして定義
- motorControlTraceの重み計算でマクロを参照するよう更新

## テスト
- テスト未実施（該当する自動テストなし）

------
https://chatgpt.com/codex/tasks/task_e_68c95c9257588323bb3c79343d2f6c35