### PR TITLE
ラインセンサ偏差をSDログへ保存

### DIFF
--- a/robotrace_v2/Core/Inc/PIDcontrol.h
+++ b/robotrace_v2/Core/Inc/PIDcontrol.h
@@ -54,6 +54,10 @@ extern float 	targetAngle;    // 目標角度
 extern float    targetAngularVelocity;  // 目標角速度
 extern int16_t  targetDist;		        // 目標X座標
 
+extern int16_t	lineTraceSenL;	// ログ用ラインセンサ合成値(左)
+extern int16_t	lineTraceSenR;	// ログ用ラインセンサ合成値(右)
+extern int16_t	lineTraceDev;	// ログ用ラインセンサ偏差
+
 extern pidParam lineTraceCtrl;
 extern pidParam veloCtrl;
 extern pidParam yawRateCtrl;

--- a/robotrace_v2/Core/Inc/SDcard.h
+++ b/robotrace_v2/Core/Inc/SDcard.h
@@ -13,7 +13,7 @@
 #ifdef LOG_RUNNING_WRITE
 #define BUFFER_SIZE_LOG 512
 #define LOG_NUM_8BIT 3
-#define LOG_NUM_16BIT 5
+#define LOG_NUM_16BIT 8
 #define LOG_NUM_32BIT 1
 #define LOG_NUM_FLOAT 1
 #define LOG_SIZE (LOG_NUM_8BIT * sizeof(uint8_t)) + (LOG_NUM_16BIT * sizeof(uint16_t)) + (LOG_NUM_32BIT * sizeof(uint32_t)) + (LOG_NUM_FLOAT * sizeof(float))

--- a/robotrace_v2/Core/Src/PIDcontrol.c
+++ b/robotrace_v2/Core/Src/PIDcontrol.c
@@ -16,6 +16,9 @@ uint8_t targetSpeed;		 // 目標速度
 float targetAngle;			 // 目標角速度
 float targetAngularVelocity; // 目標角度
 int16_t targetDist;			 // 目標X座標
+int16_t lineTraceSenL;		// ログ用ラインセンサ合成値(左)
+int16_t lineTraceSenR;		// ログ用ラインセンサ合成値(右)
+int16_t lineTraceDev;		// ログ用ラインセンサ偏差
 
 ///////////////////////////////////////////////////////////////////////////
 // モジュール名 setTargetSpeed
@@ -85,6 +88,11 @@ void motorControlTrace(void)
 		senR = (lSensor[6]);
 	}
 	Dev = senL - senR;
+
+	// ログ用に最新のラインセンサ値を保持
+	lineTraceSenL = (int16_t)senL;
+	lineTraceSenR = (int16_t)senR;
+	lineTraceDev = (int16_t)Dev;
 
 	// I成分積算
 	lineTraceCtrl.Int += (float)Dev * 0.001;

--- a/robotrace_v2/Core/Src/SDcard.c
+++ b/robotrace_v2/Core/Src/SDcard.c
@@ -211,6 +211,10 @@ void createLog(void)
 	// setLogStr("CurrentR", "%f");
 	setLogStr("lineTraceCtrl", "%d");
 	setLogStr("veloCtrl", "%d");
+	// ライントレースセンサの合成値をログに追加
+	setLogStr("senL", "%d");
+	setLogStr("senR", "%d");
+	setLogStr("Dev", "%d");
 
 	setLogStr("x", "%f");
 	setLogStr("y", "%f");
@@ -463,6 +467,7 @@ void endLog(void)
 	uint16_t marker, time, beforeTime = 0, speed, beforeSpeed = 0;
 	uint32_t distance;
 	float dt, zg;
+	int16_t logSenL = 0, logSenR = 0, logDev = 0;
 	static union
 	{
 		float f;
@@ -526,6 +531,10 @@ void endLog(void)
 		speed = logval16[1];
 		distance = logval32[0];
 		zg = logvalf[0];
+		// ログ復元時のラインセンサ値を取得
+		logSenL = (int16_t)logval16[5];
+		logSenR = (int16_t)logval16[6];
+		logDev = (int16_t)logval16[7];
 
 		if (abs(speed - beforeSpeed) > 500)
 		{
@@ -562,6 +571,9 @@ void endLog(void)
 			// (float)logval16[6] / 10000,	// CurrentR
 			(int16_t)logval16[3],		// lineTraceCtrl
 			(int16_t)logval16[4],		// veloCtrl
+			logSenL,		// senL
+			logSenR,		// senR
+			logDev,		// Dev
 			logvalf[2],		// x
 			logvalf[3]		// y
 		);

--- a/robotrace_v2/Core/Src/timer.c
+++ b/robotrace_v2/Core/Src/timer.c
@@ -131,6 +131,10 @@ void Interrupt1ms(void)
 					// (int16_t)(motorCurrentR * 10000),
 					lineTraceCtrl.pwm,
 					veloCtrl.pwm,
+					// ライントレースセンサ値
+					lineTraceSenL,
+					lineTraceSenR,
+					lineTraceDev,
 					// 32bit
 					encTotalOptimal,
 					// float型


### PR DESCRIPTION
## 概要
- motorControlTraceでラインセンサ合成値と偏差を保持
- SDカードのログ列にsenL/senR/Devを追加
- バイナリログの書き出し・変換処理を更新して新しい値をCSVへ出力

## テスト
- なし（ビルド・実機テスト未実施）

------
https://chatgpt.com/codex/tasks/task_e_68c95ee6f2c48323a5b90530a25752a9