### PR TITLE
calcROCでfabsfを使わず符号比較で絶対値計算するよう変更

### DIFF
--- a/robotrace_v2/Core/Src/courseAnalysis.c
+++ b/robotrace_v2/Core/Src/courseAnalysis.c
@@ -38,15 +38,19 @@ float calcROC(int16_t velo, float angvelo, float dt)
 	dl = (float)velo * invPulseConst; // [palse] → [mm]
 	drad = angvelo * angFactor; // [deg/s] → [rad]
 
+	// fabsfの代わりに符号で絶対値を判定する（負の値なら反転）
+	float absDrad = (drad < 0.0F) ? -drad : drad;
 	// 角速度が極小の場合は直線とみなして即座に返す
-	if (fabsf(drad) < 1e-6F)
+	if (absDrad < 1e-6F)
 	{
 		return 2000.0F;
 	}
 
 	ret = dl / drad; // 曲率半径を計算
+	// fabsfの代わりに符号で絶対値を判定する（負の値なら反転）
+	float absRet = (ret < 0.0F) ? -ret : ret;
 	// 曲率半径が大きい＝直線の場合は極大にする
-	if (fabsf(ret) > 1500.0F)
+	if (absRet > 1500.0F)
 	{
 		ret = 2000.0F;
 	}


### PR DESCRIPTION
## 概要
- calcROC内のfabsf呼び出しを符号比較による絶対値計算に置き換え
- 符号比較ロジックにコメントを追加

## テスト
- テスト未実施


------
https://chatgpt.com/codex/tasks/task_e_68c96e9eb4d4832391fb9fc465bbd600