### PR TITLE
cntSendリセットによるログ変換制御の安定化

### DIFF
--- a/robotrace_v2/Core/Src/SDcard.c
+++ b/robotrace_v2/Core/Src/SDcard.c
@@ -261,6 +261,8 @@ void initLog(void)
 {
     FRESULT fresult;
 #ifdef LOG_RUNNING_WRITE
+	// CSV変換ループの実行回数を走行ごとに正しく制御するため送信カウンタをリセット
+	cntSend = 0;
 	fresult = f_open(&fil_W, "temp", FA_OPEN_ALWAYS | FA_WRITE); // create file
 	if (fresult != FR_OK)
 	{
@@ -574,6 +576,8 @@ void endLog(void)
 	f_close(&fil);	 // 一時ファイル
 
 	sd_unmount(); // SDカードをアンマウント
+	// 連続走行時にCSV変換ループが累積しないよう送信カウンタをリセット
+	cntSend = 0;
 
 #else
 	createLog();	 // ログファイル作成


### PR DESCRIPTION
## 概要
- initLog開始時にcntSendをリセットして連続走行ごとの送信回数を初期化
- endLog完了時にもcntSendをクリアしてCSV変換ループの実行回数を安定化

## テスト
- ハードウェア依存のため未実施

------
https://chatgpt.com/codex/tasks/task_e_68cf8f047da083239d7985c3e12e599c