### PR TITLE
ログ書き込み優先フラグの導入

### DIFF
--- a/robotrace_v2/Core/Inc/SDcard.h
+++ b/robotrace_v2/Core/Inc/SDcard.h
@@ -36,6 +36,10 @@ extern int32_t encLog;
 extern bool logOverflow;     // ログバッファ上限超過フラグ
 extern bool markerOverflow;  // マーカーバッファ上限超過フラグ
 extern bool getFileNumbersError; // getFileNumbersでエラーが発生した際のフラグ
+#ifdef LOG_RUNNING_WRITE
+extern volatile bool sendSD; // flushBufをSDに送る要求フラグ(割込み共有)
+extern volatile bool logWritePriorityReq; // 割込み外での優先書き込み要求フラグ
+#endif
 //====================================//
 // プロトタイプ宣言
 //====================================//

--- a/robotrace_v2/Core/Src/SDcard.c
+++ b/robotrace_v2/Core/Src/SDcard.c
@@ -22,6 +22,7 @@ uint8_t *flushBuf = logBuffer[1];		// SD書き込み待ちバッファ
 int16_t logBuffIndex = 0;				// 一時記録バッファ書込アドレス
 uint32_t logBuffSendIndex = 0;			// flushBufに溜まったバイト数
 volatile bool sendSD = false;			// flushBufをSDへ送るフラグ(割込み共有)
+volatile bool logWritePriorityReq = false;	// 優先的にSD書き込みを要求するフラグ
 uint16_t cntSend = 0;
 uint8_t *logaddress;
 #else
@@ -275,6 +276,7 @@ void initLog(void)
 	flushBuf = logBuffer[1];			// フラッシュバッファを初期化
 	logBuffSendIndex = logBuffIndex;	// バッファのバイト数を記録
 	sendSD = false;						// 書き込み要求をリセット
+	logWritePriorityReq = false;	// 優先書き込み要求をリセット
 #else
     // 構造体配列の初期化
     memset(&logVal, 0, sizeof(logData) * BUFFER_SIZE_LOG);     // 綴りの誤りを修正
@@ -313,6 +315,7 @@ void writeLogBufferPuts(uint8_t c, uint8_t s, uint8_t i, uint8_t f, ...)
 			activeBuf = tmp; // 退避したバッファを新たなactiveに
 			logBuffIndex = 0; // 新バッファの書込位置をリセット
 			sendSD = true; // SD書き込みを要求
+			logWritePriorityReq = true; // 割込み外で即時に書き込みを行うよう要求
 		}
 
 		// バッファ配列に保存

--- a/robotrace_v2/Core/Src/timer.c
+++ b/robotrace_v2/Core/Src/timer.c
@@ -224,11 +224,19 @@ void Interrupt100us(void)
 void logWriteTask(void)
 {
 #ifdef LOG_RUNNING_WRITE
-        if (logWriteReq)
-        {
-                writeLogPuts();        // 割り込み外でSD書き込みを実行する
-                logWriteReq = false;
-        }
+		if (logWritePriorityReq)
+		{
+			writeLogPuts();	// 優先要求に応じて即時にSDへ書き込む
+			if (!sendSD)
+			{
+				logWritePriorityReq = false;	// 書き込みが完了したので優先要求を解除
+			}
+		}
+		else if (logWriteReq)
+		{
+			writeLogPuts();	// 割り込み外でSD書き込みを実行する
+			logWriteReq = false;
+		}
 #endif
 }
 /////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## 概要
- SDカード書き込み用に割り込み外で即時処理を要求する優先フラグを追加
- ログ初期化とバッファ切替処理で優先フラグを適切に制御
- メインループ側のlogWriteTaskで優先フラグを最優先に処理するよう制御フローを更新

## テスト
- 実機が必要なため未実施

------
https://chatgpt.com/codex/tasks/task_e_68cfdf1d239c832395e00448e2742fdb