### PR TITLE
printf/scanfのfloat対応をREADMEに追記

### DIFF
--- a/robotrace_v2/CMakeLists.txt
+++ b/robotrace_v2/CMakeLists.txt
@@ -90,5 +90,5 @@ target_link_libraries(${CMAKE_PROJECT_NAME}
 
     # Add user defined libraries
 )
-# Set the linker flags for printf float support
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -u _printf_float")
+# Set the linker flags for printf/scanf float support
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -u _printf_float -u _scanf_float")

--- a/robotrace_v2/README.md
+++ b/robotrace_v2/README.md
@@ -1,0 +1,10 @@
+# robotrace_v2
+
+## コンパイルオプションについて
+
+`printf` や `scanf` で `float` 型を扱えるようにするため、リンカオプションに以下のフラグを追加しています。
+
+- `-u _printf_float`
+- `-u _scanf_float`
+
+STM32 向けの newlib-nano では標準状態で浮動小数点入出力が無効なため、上記のフラグを `CMakeLists.txt` の `CMAKE_EXE_LINKER_FLAGS` に追加することでサポートを有効化しています。


### PR DESCRIPTION
## 概要
- READMEにprintf/scanfでfloat型を扱うためのリンカオプションを追記
- CMakeLists.txtのリンカフラグに`-u _scanf_float`を加え、コメントを更新

## テスト
- 未実施


------
https://chatgpt.com/codex/tasks/task_e_68d29813be9883239d8ef6fdf795402a