### PR TITLE
マーカー検知ログの追加とログ周期の高速化

### DIFF
--- a/robotrace_v2/Core/Inc/SDcard.h
+++ b/robotrace_v2/Core/Inc/SDcard.h
@@ -13,9 +13,9 @@
 
 #ifdef LOG_RUNNING_WRITE
 #define BUFFER_SIZE_LOG 512
-#define LOG_NUM_8BIT 3
+#define LOG_NUM_8BIT 7
 #define LOG_NUM_16BIT 5
-#define LOG_NUM_32BIT 1
+#define LOG_NUM_32BIT 7
 #define LOG_NUM_FLOAT 1
 #define LOG_SIZE (LOG_NUM_8BIT * sizeof(uint8_t)) + (LOG_NUM_16BIT * sizeof(uint16_t)) + (LOG_NUM_32BIT * sizeof(uint32_t)) + (LOG_NUM_FLOAT * sizeof(float))
 #else

--- a/robotrace_v2/Core/Inc/markerSensor.h
+++ b/robotrace_v2/Core/Inc/markerSensor.h
@@ -22,6 +22,23 @@
 //====================================//
 extern uint8_t  SGmarker;
 extern uint8_t  crossLine;
+
+// ログ保存用のマーカー検知情報
+typedef struct
+{
+	uint8_t	checkStart;
+	uint8_t	nowMarker;
+	uint8_t	existMarker;
+	uint8_t	result;
+	int32_t	encMarkerL;
+	int32_t	encMarkerR;
+	int32_t	encMarkerN;
+	int32_t	nowEncTotalN;
+	int32_t	distL;
+	int32_t	distR;
+} MarkerCheckLog;
+
+extern volatile MarkerCheckLog markerCheckLog;
 //====================================//
 // プロトタイプ宣言
 //====================================//

--- a/robotrace_v2/Core/Src/SDcard.c
+++ b/robotrace_v2/Core/Src/SDcard.c
@@ -176,7 +176,16 @@ void createLog(void)
 	// setLogStr("CurrentR", "%f");
 	setLogStr("lineTraceCtrl", "%d");
 	setLogStr("veloCtrl", "%d");
-
+	setLogStr("markerCheckStart", "%d");
+	setLogStr("markerNow", "%d");
+	setLogStr("markerExist", "%d");
+	setLogStr("markerResult", "%d");
+	setLogStr("encMarkerL", "%d");
+	setLogStr("encMarkerR", "%d");
+	setLogStr("encMarkerN", "%d");
+	setLogStr("markerEncTotal", "%d");
+	setLogStr("markerDistL", "%d");
+	setLogStr("markerDistR", "%d");
 	setLogStr("x", "%f");
 	setLogStr("y", "%f");
 #else
@@ -507,6 +516,16 @@ void endLog(void)
 		speed = logval16[1];
 		distance = logval32[0];
 		zg = logvalf[0];
+		uint8_t markerCheckStart = logval8[3];
+		uint8_t markerNow = logval8[4];
+		uint8_t markerExist = logval8[5];
+		uint8_t markerResult = logval8[6];
+		int32_t encMarkerL = (int32_t)logval32[1];
+		int32_t encMarkerR = (int32_t)logval32[2];
+		int32_t encMarkerN = (int32_t)logval32[3];
+		int32_t markerEncTotal = (int32_t)logval32[4];
+		int32_t markerDistL = (int32_t)logval32[5];
+		int32_t markerDistR = (int32_t)logval32[6];
 
 		if (abs(speed - beforeSpeed) > 500)
 		{
@@ -533,16 +552,21 @@ void endLog(void)
 			marker,
 			distance,
 			logvalf[1],		// ROC
-
 			logval8[0],		// targetSpeed
 			logval8[2],		// modeCurve
 			logval16[2],	// optimalIndex
-			// (int16_t)logval16[3],		// motorpwmL
-			// (int16_t)logval16[4],		// motorpwmR
-			// (float)logval16[5] / 10000,	// CurrentL
-			// (float)logval16[6] / 10000,	// CurrentR
 			(int16_t)logval16[3],		// lineTraceCtrl
 			(int16_t)logval16[4],		// veloCtrl
+			markerCheckStart,
+			markerNow,
+			markerExist,
+			markerResult,
+			encMarkerL,
+			encMarkerR,
+			encMarkerN,
+			markerEncTotal,
+			markerDistL,
+			markerDistR,
 			logvalf[2],		// x
 			logvalf[3]		// y
 		);

--- a/robotrace_v2/Core/Src/markerSensor.c
+++ b/robotrace_v2/Core/Src/markerSensor.c
@@ -8,6 +8,9 @@
 uint8_t SGmarker = 0;
 uint8_t crossLine = 0;
 
+// ログ保存用のマーカー検知情報を保持
+volatile MarkerCheckLog markerCheckLog = {0};
+
 /////////////////////////////////////////////////////////////////////
 // モジュール名 getMarksensor
 // 処理概要     マーカーセンサの値を取得
@@ -41,8 +44,12 @@ uint8_t checkMarker(void)
 	static int32_t encMarkerL = 0, encMarkerR = 1, encMarkerN, nowEncTotalN;
 	static int32_t distL, distR, distN;
 
-	nowMarker = getMarkerSensor(); // マーカーセンサ値を取得
-	nowEncTotalN = encTotalN;
+		nowMarker = getMarkerSensor(); // マーカーセンサ値を取得
+		nowEncTotalN = encTotalN;
+
+		// ログ用データに現在の読み値を保存
+		markerCheckLog.nowMarker = nowMarker;
+		markerCheckLog.nowEncTotalN = nowEncTotalN;
 
 	// 反応があればマーカー幅計測開始
 	if (nowMarker > 0 && checkStart == 0)
@@ -111,7 +118,17 @@ uint8_t checkMarker(void)
 		ret = CROSSLINE;
 	}
 
-	return ret;
+		// ログ用データに検知状態を保存
+		markerCheckLog.checkStart = checkStart;
+		markerCheckLog.existMarker = existMarker;
+		markerCheckLog.encMarkerL = encMarkerL;
+		markerCheckLog.encMarkerR = encMarkerR;
+		markerCheckLog.encMarkerN = encMarkerN;
+		markerCheckLog.distL = distL;
+		markerCheckLog.distR = distR;
+		markerCheckLog.result = ret;
+
+        return ret;
 }
 /////////////////////////////////////////////////////////////
 // モジュール名 checkCrossLine

--- a/robotrace_v2/Core/Src/timer.c
+++ b/robotrace_v2/Core/Src/timer.c
@@ -10,6 +10,7 @@ int32_t cnt10 = 0;
 int32_t encPulse5ms = 0; // 5ms間のエンコーダパルスを累積
 float bootTime;
 static volatile bool logWriteReq = false;
+static float straightDistanceAcc = 0.0F; // 直線距離加算用の一時変数
 /////////////////////////////////////////////////////////////////////
 // モジュール名 Interrupt1ms
 // 処理概要     タイマー割り込み(1ms)
@@ -88,19 +89,30 @@ void Interrupt1ms(void)
 	else
 	{
 		// 走行中に処理
-		if (encLog >= encMM(CALCDISTANCE_SHORTCUT))
+		if (cntLog >= 1)
 		{
-			// 一定距離ごとに処理
-			static float rocCorrection = 0;
+			// 1ms周期での直線判定とログ保存処理
+			static float rocCorrection = 0.0F;
+			float deltaDistanceMm = 0.0F;
+			int32_t addDistanceMm = 0;
+
 			// ROC(曲率半径)計算
-			rocCorrection = calcROC(encCurrentN, BMI088val.gyro.z, (float)cntLog / 1000);
-			if (fabs(rocCorrection) >= 700.0F) // 直線判断
+			rocCorrection = calcROC(encCurrentN, BMI088val.gyro.z, (float)cntLog / 1000.0F);
+			if (fabsf(rocCorrection) >= 700.0F) // 直線判断
 			{
-				straightMeter += CALCDISTANCE_SHORTCUT; // 距離積算
+				deltaDistanceMm = fabsf((float)encCurrentN) / PALSE_MILLIMETER;
+				straightDistanceAcc += deltaDistanceMm;
+				addDistanceMm = (int32_t)straightDistanceAcc;
+				if (addDistanceMm > 0)
+				{
+					straightMeter += addDistanceMm;
+					straightDistanceAcc -= (float)addDistanceMm;
+				}
 			}
 			else
 			{
 				straightMeter = 0;
+				straightDistanceAcc = 0.0F;
 			}
 
 			if (straightMeter >= 100) // 直線が100mm以上のとき
@@ -110,7 +122,7 @@ void Interrupt1ms(void)
 
 			if (modeLOG)
 			{
-				// CALCDISTANCEごとにログを保存
+				// 1ms周期でログを保存
 #ifdef LOG_RUNNING_WRITE
 				writeLogBufferPuts(
 					LOG_NUM_8BIT,
@@ -121,27 +133,34 @@ void Interrupt1ms(void)
 					targetSpeed,
 					courseMarker,
 					modeCurve,
+					markerCheckLog.checkStart,
+					markerCheckLog.nowMarker,
+					markerCheckLog.existMarker,
+					markerCheckLog.result,
 					// 16bit
 					cntRun,
 					encCurrentN,
 					optimalIndex,
-					// motorpwmL,
-					// motorpwmR,
-					// (int16_t)(motorCurrentL * 10000),
-					// (int16_t)(motorCurrentR * 10000),
 					lineTraceCtrl.pwm,
 					veloCtrl.pwm,
 					// 32bit
-					encTotalOptimal,
+					(uint32_t)encTotalOptimal,
+					(uint32_t)markerCheckLog.encMarkerL,
+					(uint32_t)markerCheckLog.encMarkerR,
+					(uint32_t)markerCheckLog.encMarkerN,
+					(uint32_t)markerCheckLog.nowEncTotalN,
+					(uint32_t)markerCheckLog.distL,
+					(uint32_t)markerCheckLog.distR,
 					// float型
 					BMI088val.gyro.z
 				);
 #else
 				writeLogBufferPrint(); // バッファにログを保存
-				cntLog = 0;
 #endif
-				encLog = 0;	// ログ用エンコーダパルスをリセット
 			}
+
+			cntLog = 0;
+			encLog = 0; // ログ用エンコーダパルスをリセット
 		}
 	}
 


### PR DESCRIPTION
## 概要
- マーカーセンサの検知状況と距離情報を保持するログ構造体を追加し、`checkMarker()` から更新するよう変更
- SDカードのログフォーマットを拡張し、マーカー関連値を CSV 出力に含める処理を実装
- タイマ割り込みでのログ取得周期を 1ms に短縮し、直線判定の積算処理と共に新しいログ値を記録

## テスト
- 未実施（実機での動作確認が必要）

------
https://chatgpt.com/codex/tasks/task_e_68d9127b5d648323bd13c124f2b1b33e