### PR TITLE
速度フィードフォワード係数の整数化と設定保存対応

### DIFF
--- a/robotrace_v2/Core/Inc/PIDcontrol.h
+++ b/robotrace_v2/Core/Inc/PIDcontrol.h
@@ -38,12 +38,12 @@
 #define KD5		5
 
 typedef struct {
-    uint8_t *name;
-    int16_t kp;
-    int16_t ki;
-    int16_t kd;
-    float   Int;
-    int16_t pwm;
+	uint8_t *name;
+	int16_t kp;
+	int16_t ki;
+	int16_t kd;
+	float	Int;
+	int16_t pwm;
 } pidParam;
 
 //====================================//
@@ -59,6 +59,7 @@ extern pidParam veloCtrl;
 extern pidParam yawRateCtrl;
 extern pidParam yawCtrl;
 extern pidParam distCtrl;
+extern int16_t speedFeedForwardGain;
 //====================================//
 // プロトタイプ宣言
 //====================================//
@@ -69,6 +70,8 @@ void setTargetDist (float dist);
 void resetSpeedPID (void);
 void writePIDparameters(pidParam *pid);
 void readPIDparameters(pidParam *pid);
+void writeSpeedFeedForwardGain(int16_t gain);
+void readSpeedFeedForwardGain(int16_t *gain);
 void motorControlTrace(void);
 void motorControlSpeed(void);
 void motorControlYawRate(void);

--- a/robotrace_v2/Core/Src/PIDcontrol.c
+++ b/robotrace_v2/Core/Src/PIDcontrol.c
@@ -12,12 +12,39 @@ pidParam yawRateCtrl = {"yawRate", KP3, KI3, KD3, 0, 0};
 pidParam yawCtrl = {"yaw", KP4, KI4, KD4, 0, 0};
 pidParam distCtrl = {"dist", KP5, KI5, KD5, 0, 0};
 
+// 速度フィードフォワード係数のデフォルト値(実機で調整することを想定)
+#define SPEED_FEEDFORWARD_GAIN_DEFAULT 4
+// 速度フィードフォワード係数(セットアップ画面から変更可能)
+int16_t speedFeedForwardGain = SPEED_FEEDFORWARD_GAIN_DEFAULT;
+
 uint8_t targetSpeed;		 // 目標速度
 float targetAngle;			 // 目標角速度
 float targetAngularVelocity; // 目標角度
 int16_t targetDist;			 // 目標X座標
 static int16_t speedTargetBefore = 0;	// 速度PID用の前回目標値
 static int16_t speedEncoderBefore = 0;	// 速度PID用の前回偏差
+
+///////////////////////////////////////////////////////////////////////////
+// モジュール名 calcSpeedFeedForward
+// 処理概要     目標速度からフィードフォワード項を算出
+// 引数         targetPulse:目標速度(パルス換算)
+// 戻り値       フィードフォワードPWM値
+///////////////////////////////////////////////////////////////////////////
+static int16_t calcSpeedFeedForward(int16_t targetPulse)
+{
+	int32_t feedForward;
+
+	// 目標速度と係数から整数演算でフィードフォワード補償量を算出
+	feedForward = (int32_t)targetPulse * speedFeedForwardGain;
+
+	/* フィードフォワードで加算するPWM値を安全範囲に制限 */
+	if (feedForward > 1000)
+		feedForward = 1000;
+	else if (feedForward < -1000)
+		feedForward = -1000;
+
+	return (int16_t)feedForward;
+}
 
 ///////////////////////////////////////////////////////////////////////////
 // モジュール名 setTargetSpeed
@@ -133,6 +160,7 @@ void motorControlTrace(void)
 void motorControlSpeed(void)
 {
 	int32_t iP, iI, iD, iRet, Dev, Dif;
+	int16_t feedForward;
 
 	// 駆動モーター用PWM値計算
 	Dev = (int16_t)targetSpeed - encCurrentN; // 偏差
@@ -141,12 +169,14 @@ void motorControlSpeed(void)
 		veloCtrl.Int = 0;
 
 	veloCtrl.Int += (float)Dev * 0.001; // 時間積分
-	Dif = Dev - speedEncoderBefore;			// 微分　dゲイン1/1000倍
+	Dif = Dev - speedEncoderBefore;		         // 微分　dゲイン1/1000倍
 
-	iP = veloCtrl.kp * Dev;			 // 比例
+	iP = veloCtrl.kp * Dev;		         // 比例
 	iI = veloCtrl.ki * veloCtrl.Int; // 積分
-	iD = veloCtrl.kd * Dif;			 // 微分
-	iRet = iP + iI + iD;
+	iD = veloCtrl.kd * Dif;		         // 微分
+	feedForward = calcSpeedFeedForward((int16_t)targetSpeed); // フィードフォワード項
+	// PID制御出力にフィードフォワード補償を加えて応答を改善
+	iRet = iP + iI + iD + feedForward;
 	iRet = iRet;
 
 	// PWMの上限の設定
@@ -156,7 +186,7 @@ void motorControlSpeed(void)
 		iRet = -900;
 
 	veloCtrl.pwm = iRet;
-	speedEncoderBefore = Dev;			 // 次回はこの値が1ms前の値となる
+	speedEncoderBefore = Dev;		       // 次回はこの値が1ms前の値となる
 	speedTargetBefore = targetSpeed; // 前回の目標値を記録
 }
 ///////////////////////////////////////////////////////////////////////////
@@ -317,4 +347,58 @@ void readPIDparameters(pidParam *pid)
 	}
 
 	f_close(&fil);
+}
+
+///////////////////////////////////////////////////////////////////////////
+// モジュール名 writeSpeedFeedForwardGain
+// 処理概要     速度フィードフォワード係数をSDカードへ保存
+// 引数         gain:保存する係数
+// 戻り値       なし
+///////////////////////////////////////////////////////////////////////////
+void writeSpeedFeedForwardGain(int16_t gain)
+{
+	FIL fil;
+	FRESULT fresult;
+	uint8_t fileName[20] = PATH_SETTING;
+
+	// ファイル名を生成して係数を書き込み
+	strcat(fileName, "speed_ff.txt");
+	fresult = f_open(&fil, fileName, FA_OPEN_ALWAYS | FA_WRITE);
+	if (fresult == FR_OK)
+	{
+		f_lseek(&fil, 0);	// 既存内容を先頭から上書き
+		f_truncate(&fil);
+		f_printf(&fil, "%03d", gain);
+	}
+
+	f_close(&fil);
+}
+
+///////////////////////////////////////////////////////////////////////////
+// モジュール名 readSpeedFeedForwardGain
+// 処理概要     速度フィードフォワード係数をSDカードから読み込む
+// 引数         gain:読み込んだ係数の格納先
+// 戻り値       なし
+///////////////////////////////////////////////////////////////////////////
+void readSpeedFeedForwardGain(int16_t *gain)
+{
+	FIL fil;
+	FRESULT fresult;
+	uint8_t fileName[20] = PATH_SETTING;
+	TCHAR gainStr[10];
+	int16_t readGain = *gain;
+
+	// ファイル名を生成して係数を読み込み
+	strcat(fileName, "speed_ff.txt");
+	fresult = f_open(&fil, fileName, FA_OPEN_EXISTING | FA_READ);
+	if (fresult == FR_OK)
+	{
+		if (f_gets(gainStr, sizeof(gainStr), &fil) != NULL)
+		{
+			sscanf(gainStr, "%hd", &readGain);
+		}
+	}
+
+	f_close(&fil);
+	*gain = readGain;
 }

--- a/robotrace_v2/Core/Src/control.c
+++ b/robotrace_v2/Core/Src/control.c
@@ -136,6 +136,7 @@ void initSystem(void)
 			// 前回のPIDゲインを取得
 			readPIDparameters(&lineTraceCtrl);
 			readPIDparameters(&veloCtrl);
+			readSpeedFeedForwardGain(&speedFeedForwardGain);	// 速度フィードフォワード係数も読み出す
 			readPIDparameters(&yawRateCtrl);
 			readPIDparameters(&yawCtrl);
 			readPIDparameters(&distCtrl);
@@ -394,6 +395,7 @@ void loopSystem(void)
 			{
 				writePIDparameters(&lineTraceCtrl);
 				writePIDparameters(&veloCtrl);
+				writeSpeedFeedForwardGain(speedFeedForwardGain);	// 速度フィードフォワード係数も保存
 				writePIDparameters(&yawRateCtrl);
 				writePIDparameters(&yawCtrl);
 				writePIDparameters(&distCtrl);

--- a/robotrace_v2/Core/Src/setup.c
+++ b/robotrace_v2/Core/Src/setup.c
@@ -752,6 +752,8 @@ static void setup_pid_speed(void)
 		ssd1306_printf(Font_7x10, "ki:");
 		ssd1306_SetCursor(0, 44);
 		ssd1306_printf(Font_7x10, "kd:");
+		ssd1306_SetCursor(0, 56);
+		ssd1306_printf(Font_7x10, "ff:");	// フィードフォワード係数の表示欄
 		ssd1306_SetCursor(60, 30);
 		ssd1306_printf(Font_7x10, "pwm:");
 	}
@@ -773,7 +775,7 @@ static void setup_pid_speed(void)
 	}
 
 	// ゲイン表示
-	dataTuningUD(&pattern.gain, 1, 3, 1); // 調整対象のゲインを選択
+	dataTuningUD(&pattern.gain, 1, 4, 1); // 調整対象のゲインを選択(フィードフォワード係数を含む)
 	if (testFlags.trace_test == 0)
 	{
 		ssd1306_SetCursor(21, 18);
@@ -781,16 +783,24 @@ static void setup_pid_speed(void)
 			ssd1306_printfB(Font_7x10, "%3d", veloCtrl.kp);
 		else
 			ssd1306_printf(Font_7x10, "%3d", veloCtrl.kp);
-			ssd1306_SetCursor(21, 32);
+
+		ssd1306_SetCursor(21, 32);
 		if (pattern.gain == 2)
 			ssd1306_printfB(Font_7x10, "%3d", veloCtrl.ki);
 		else
 			ssd1306_printf(Font_7x10, "%3d", veloCtrl.ki);
-			ssd1306_SetCursor(21, 44);
+
+		ssd1306_SetCursor(21, 44);
 		if (pattern.gain == 3)
 			ssd1306_printfB(Font_7x10, "%3d", veloCtrl.kd);
 		else
 			ssd1306_printf(Font_7x10, "%3d", veloCtrl.kd);
+
+		ssd1306_SetCursor(21, 56);
+		if (pattern.gain == 4)
+			ssd1306_printfB(Font_7x10, "%3d", speedFeedForwardGain);
+		else
+			ssd1306_printf(Font_7x10, "%3d", speedFeedForwardGain);
 
 		// 制御量表示
 		ssd1306_SetCursor(88, 30);
@@ -810,6 +820,10 @@ static void setup_pid_speed(void)
 		case 3:
 			// kdゲインを調整
 			dataTuningLR(&veloCtrl.kd, 1, 0, 255);
+			break;
+		case 4:
+			// フィードフォワード係数を調整
+			dataTuningLR(&speedFeedForwardGain, 1, 0, 255);
 			break;
 		}
 	}

--- a/robotrace_v2/Core/Src/setup.c
+++ b/robotrace_v2/Core/Src/setup.c
@@ -747,13 +747,13 @@ static void setup_pid_speed(void)
 		ssd1306_printf(Font_6x8, "Speed PID");
 
 		ssd1306_SetCursor(0, 18);
-		ssd1306_printf(Font_7x10, "kp:");
-		ssd1306_SetCursor(0, 32);
-		ssd1306_printf(Font_7x10, "ki:");
-		ssd1306_SetCursor(0, 44);
-		ssd1306_printf(Font_7x10, "kd:");
-		ssd1306_SetCursor(0, 56);
-		ssd1306_printf(Font_7x10, "ff:");	// フィードフォワード係数の表示欄
+		ssd1306_printf(Font_6x8, "kp:");
+		ssd1306_SetCursor(0, 30);
+		ssd1306_printf(Font_6x8, "ki:");
+		ssd1306_SetCursor(0, 42);
+		ssd1306_printf(Font_6x8, "kd:");
+		ssd1306_SetCursor(0, 54);
+		ssd1306_printf(Font_6x8, "ff:");	// フィードフォワード係数の表示欄
 		ssd1306_SetCursor(60, 30);
 		ssd1306_printf(Font_7x10, "pwm:");
 	}
@@ -780,27 +780,27 @@ static void setup_pid_speed(void)
 	{
 		ssd1306_SetCursor(21, 18);
 		if (pattern.gain == 1)
-			ssd1306_printfB(Font_7x10, "%3d", veloCtrl.kp);
+			ssd1306_printfB(Font_6x8, "%3d", veloCtrl.kp);
 		else
-			ssd1306_printf(Font_7x10, "%3d", veloCtrl.kp);
+			ssd1306_printf(Font_6x8, "%3d", veloCtrl.kp);
 
-		ssd1306_SetCursor(21, 32);
+		ssd1306_SetCursor(21, 30);
 		if (pattern.gain == 2)
-			ssd1306_printfB(Font_7x10, "%3d", veloCtrl.ki);
+			ssd1306_printfB(Font_6x8, "%3d", veloCtrl.ki);
 		else
-			ssd1306_printf(Font_7x10, "%3d", veloCtrl.ki);
+			ssd1306_printf(Font_6x8, "%3d", veloCtrl.ki);
 
-		ssd1306_SetCursor(21, 44);
+		ssd1306_SetCursor(21, 42);
 		if (pattern.gain == 3)
-			ssd1306_printfB(Font_7x10, "%3d", veloCtrl.kd);
+			ssd1306_printfB(Font_6x8, "%3d", veloCtrl.kd);
 		else
-			ssd1306_printf(Font_7x10, "%3d", veloCtrl.kd);
+			ssd1306_printf(Font_6x8, "%3d", veloCtrl.kd);
 
-		ssd1306_SetCursor(21, 56);
+		ssd1306_SetCursor(21, 54);
 		if (pattern.gain == 4)
-			ssd1306_printfB(Font_7x10, "%3d", speedFeedForwardGain);
+			ssd1306_printfB(Font_6x8, "%3d", speedFeedForwardGain);
 		else
-			ssd1306_printf(Font_7x10, "%3d", speedFeedForwardGain);
+			ssd1306_printf(Font_6x8, "%3d", speedFeedForwardGain);
 
 		// 制御量表示
 		ssd1306_SetCursor(88, 30);


### PR DESCRIPTION
## 概要
- 速度フィードフォワード係数を整数型に変更し、SDカードから読み書きできる管理機能を追加
- 速度PIDセットアップ画面にフィードフォワード係数の表示・調整項目を追加し、調整結果を保存

## テスト
- [ ] テスト未実施

------
https://chatgpt.com/codex/tasks/task_e_68e149fbbe0483239bac2c0216ea4e86