### PR TITLE
DWT初期化時に取得したバッテリ電圧の共有対応

### DIFF
--- a/robotrace_v2/Core/Inc/PIDcontrol.h
+++ b/robotrace_v2/Core/Inc/PIDcontrol.h
@@ -50,6 +50,7 @@ typedef struct {
 // グローバル変数の宣言
 //====================================//
 extern uint8_t	targetSpeed;	// 目標速度
+extern float	targetSpeedCommand_m_s;	// setTargetSpeedで指定した速度指令値[m/s]
 extern float 	targetAngle;    // 目標角度
 extern float    targetAngularVelocity;  // 目標角速度
 extern int16_t  targetDist;		        // 目標X座標
@@ -60,6 +61,21 @@ extern pidParam yawRateCtrl;
 extern pidParam yawCtrl;
 extern pidParam distCtrl;
 extern int16_t speedFeedForwardGain;
+
+//====================================//
+// 速度フィードフォワード関連定義
+//====================================//
+#define SPEED_FEEDFORWARD_GAIN_DEFAULT          20      // Crr×1000 の初期値(例:0.020)
+#define SPEED_FEEDFORWARD_GEAR_RATIO            2.0f    // ギア比 G
+#define SPEED_FEEDFORWARD_EFFICIENCY            0.90f   // ギア効率 η
+#define SPEED_FEEDFORWARD_KV_RPM_PER_V          2710.0f // Kv[rpm/V]
+#define SPEED_FEEDFORWARD_S_RPM_PER_MNM         2240.0f // S[rpm/mNm]
+#define SPEED_FEEDFORWARD_WHEEL_DIAMETER_MM     24.0f   // ホイール径 D[mm]
+#define SPEED_FEEDFORWARD_MASS_KG               0.123f  // 車体質量 m[kg]
+#define SPEED_FEEDFORWARD_GRAVITY               9.80665f        // 重力加速度 g[m/s^2]
+#define SPEED_FEEDFORWARD_SIGN_DEADBAND_MM_S    0.001f  // sgn(v) 判定のデッドバンド[mm/s]
+#define SPEED_FEEDFORWARD_PWM_MAX_DEFAULT       1000    // PWM_MAX のデフォルト値
+#define SPEED_FEEDFORWARD_CRR_SCALE             0.001f  // speedFeedForwardGain→Crr 変換係数
 //====================================//
 // プロトタイプ宣言
 //====================================//

--- a/robotrace_v2/Core/Inc/PIDcontrol.h
+++ b/robotrace_v2/Core/Inc/PIDcontrol.h
@@ -37,6 +37,19 @@
 #define KI5		1
 #define KD5		5
 
+// 速度フィードフォワード関連定義
+#define SPEED_FEEDFORWARD_GAIN_DEFAULT          150      // Crr×1000 の初期値(例:0.020)
+#define SPEED_FEEDFORWARD_GEAR_RATIO            2.0f    // ギア比 G
+#define SPEED_FEEDFORWARD_EFFICIENCY            0.90f   // ギア効率 η
+#define SPEED_FEEDFORWARD_KV_RPM_PER_V          2710.0f // Kv[rpm/V]
+#define SPEED_FEEDFORWARD_S_RPM_PER_MNM         2240.0f // S[rpm/mNm]
+#define SPEED_FEEDFORWARD_WHEEL_DIAMETER_MM     24.0f   // ホイール径 D[mm]
+#define SPEED_FEEDFORWARD_MASS_KG               0.123f  // 車体質量 m[kg]
+#define SPEED_FEEDFORWARD_GRAVITY               9.80665f        // 重力加速度 g[m/s^2]
+#define SPEED_FEEDFORWARD_SIGN_DEADBAND_MM_S    0.001f  // sgn(v) 判定のデッドバンド[mm/s]
+#define SPEED_FEEDFORWARD_PWM_MAX_DEFAULT       1000    // PWM_MAX のデフォルト値
+#define SPEED_FEEDFORWARD_CRR_SCALE             0.001f  // speedFeedForwardGain→Crr 変換係数
+
 typedef struct {
 	uint8_t *name;
 	int16_t kp;
@@ -62,20 +75,6 @@ extern pidParam yawCtrl;
 extern pidParam distCtrl;
 extern int16_t speedFeedForwardGain;
 
-//====================================//
-// 速度フィードフォワード関連定義
-//====================================//
-#define SPEED_FEEDFORWARD_GAIN_DEFAULT          20      // Crr×1000 の初期値(例:0.020)
-#define SPEED_FEEDFORWARD_GEAR_RATIO            2.0f    // ギア比 G
-#define SPEED_FEEDFORWARD_EFFICIENCY            0.90f   // ギア効率 η
-#define SPEED_FEEDFORWARD_KV_RPM_PER_V          2710.0f // Kv[rpm/V]
-#define SPEED_FEEDFORWARD_S_RPM_PER_MNM         2240.0f // S[rpm/mNm]
-#define SPEED_FEEDFORWARD_WHEEL_DIAMETER_MM     24.0f   // ホイール径 D[mm]
-#define SPEED_FEEDFORWARD_MASS_KG               0.123f  // 車体質量 m[kg]
-#define SPEED_FEEDFORWARD_GRAVITY               9.80665f        // 重力加速度 g[m/s^2]
-#define SPEED_FEEDFORWARD_SIGN_DEADBAND_MM_S    0.001f  // sgn(v) 判定のデッドバンド[mm/s]
-#define SPEED_FEEDFORWARD_PWM_MAX_DEFAULT       1000    // PWM_MAX のデフォルト値
-#define SPEED_FEEDFORWARD_CRR_SCALE             0.001f  // speedFeedForwardGain→Crr 変換係数
 //====================================//
 // プロトタイプ宣言
 //====================================//

--- a/robotrace_v2/Core/Inc/control.h
+++ b/robotrace_v2/Core/Inc/control.h
@@ -77,6 +77,7 @@ extern uint8_t autoStart;	 // 5走を自動で開始する
 
 extern uint16_t analogVal1[10]; // ADC結果格納配列
 extern uint16_t analogVal2[4];	// ADC結果格納配列
+extern float batteryVoltage_V;	// DWT初期化後に取得したバッテリ電圧[V]
 
 // パラメータ関連
 extern speedParam tgtParam;

--- a/robotrace_v2/Core/Src/PIDcontrol.c
+++ b/robotrace_v2/Core/Src/PIDcontrol.c
@@ -191,7 +191,8 @@ void motorControlTrace(void)
 void motorControlSpeed(void)
 {
 	int32_t iP, iI, iD, iRet, Dev, Dif;
-	int16_t feedForward;
+	static int16_t feedForwardPwm = 0;	/* フィードフォワードPWM値を保持して再利用 */
+	static uint8_t feedForwardInitialized = 0;	/* 初回実行でフィードフォワードを計算したかのフラグ */
 	float targetSpeed_mm_s;
 	float crr;
 
@@ -202,19 +203,24 @@ void motorControlSpeed(void)
 		veloCtrl.Int = 0;
 
 	veloCtrl.Int += (float)Dev * 0.001; // 時間積分
-	Dif = Dev - speedEncoderBefore;		         // 微分　dゲイン1/1000倍
+	Dif = Dev - speedEncoderBefore;		  // 微分　dゲイン1/1000倍
 
-	iP = veloCtrl.kp * Dev;		         // 比例
+	iP = veloCtrl.kp * Dev;		  // 比例
 	iI = veloCtrl.ki * veloCtrl.Int; // 積分
-	iD = veloCtrl.kd * Dif;		         // 微分
-	// 物理パラメータを用いてフィードフォワード電圧を算出
-	targetSpeed_mm_s = targetSpeedCommand_m_s * 1000.0f;	// setTargetSpeedで保持した[m/s]を[mm/s]へ換算
-	/* control.cで計測済みのバッテリ電圧[V]を使用 */
-	crr = (float)speedFeedForwardGain * SPEED_FEEDFORWARD_CRR_SCALE; // 転がり抵抗係数Crr
-	feedForward = calcSpeedFeedForward(targetSpeed_mm_s, batteryVoltage_V,
-			SPEED_FEEDFORWARD_PWM_MAX_DEFAULT, crr); // フィードフォワード項
+	iD = veloCtrl.kd * Dif;		  // 微分
+	// 目標値が変化したタイミングのみフィードフォワード値を更新
+	if ((targetSpeed != speedTargetBefore) || !feedForwardInitialized)
+	{
+		// 物理パラメータを用いてフィードフォワード電圧を算出
+		targetSpeed_mm_s = targetSpeedCommand_m_s * 1000.0f;	// setTargetSpeedで保持した[m/s]を[mm/s]へ換算
+		/* control.cで計測済みのバッテリ電圧[V]を使用 */
+		crr = (float)speedFeedForwardGain * SPEED_FEEDFORWARD_CRR_SCALE;	// 転がり抵抗係数Crr
+		feedForwardPwm = calcSpeedFeedForward(targetSpeed_mm_s, batteryVoltage_V,
+				SPEED_FEEDFORWARD_PWM_MAX_DEFAULT, crr);	// フィードフォワード項
+		feedForwardInitialized = 1; /* 更新済みを記録 */
+	}
 	// PID制御出力にフィードフォワード補償を加えて応答を改善
-	iRet = iP + iI + iD + feedForward;
+	iRet = iP + iI + iD + feedForwardPwm;
 	iRet = iRet;
 
 	// PWMの上限の設定
@@ -224,7 +230,7 @@ void motorControlSpeed(void)
 		iRet = -900;
 
 	veloCtrl.pwm = iRet;
-	speedEncoderBefore = Dev;		       // 次回はこの値が1ms前の値となる
+	speedEncoderBefore = Dev;		      // 次回はこの値が1ms前の値となる
 	speedTargetBefore = targetSpeed; // 前回の目標値を記録
 }
 ///////////////////////////////////////////////////////////////////////////

--- a/robotrace_v2/Core/Src/PIDcontrol.c
+++ b/robotrace_v2/Core/Src/PIDcontrol.c
@@ -12,38 +12,68 @@ pidParam yawRateCtrl = {"yawRate", KP3, KI3, KD3, 0, 0};
 pidParam yawCtrl = {"yaw", KP4, KI4, KD4, 0, 0};
 pidParam distCtrl = {"dist", KP5, KI5, KD5, 0, 0};
 
-// 速度フィードフォワード係数のデフォルト値(実機で調整することを想定)
-#define SPEED_FEEDFORWARD_GAIN_DEFAULT 4
-// 速度フィードフォワード係数(セットアップ画面から変更可能)
+// 速度フィードフォワード係数(セットアップ画面から変更可能: Crr×1000)
 int16_t speedFeedForwardGain = SPEED_FEEDFORWARD_GAIN_DEFAULT;
 
 uint8_t targetSpeed;		 // 目標速度
+float targetSpeedCommand_m_s;	// setTargetSpeedで指定した速度指令値[m/s]
 float targetAngle;			 // 目標角速度
 float targetAngularVelocity; // 目標角度
 int16_t targetDist;			 // 目標X座標
 static int16_t speedTargetBefore = 0;	// 速度PID用の前回目標値
 static int16_t speedEncoderBefore = 0;	// 速度PID用の前回偏差
+extern float batteryVoltage_V;	// control.cで保持したバッテリ電圧[V]
 
 ///////////////////////////////////////////////////////////////////////////
 // モジュール名 calcSpeedFeedForward
 // 処理概要     目標速度からフィードフォワード項を算出
-// 引数         targetPulse:目標速度(パルス換算)
+// 引数         targetSpeed_mm_s:目標速度[mm/s], batteryVoltage:バッテリ電圧[V]
+//              pwm_max:PWM最大値, crr:転がり抵抗係数Crr
 // 戻り値       フィードフォワードPWM値
 ///////////////////////////////////////////////////////////////////////////
-static int16_t calcSpeedFeedForward(int16_t targetPulse)
+static int16_t calcSpeedFeedForward(float targetSpeed_mm_s, float batteryVoltage, int16_t pwm_max, float crr)
 {
-	int32_t feedForward;
+	float sign;
+	float kv_ff;              // [V/(mm/s)]
+	float wheelDiameter_m;    // [m]
+	float tau_wheel_per_mNm;  // [mNm]
+	float v_bias;             // [V]
+	float voltageRequest;     // [V]
+	float pwm;
 
-	// 目標速度と係数から整数演算でフィードフォワード補償量を算出
-	feedForward = (int32_t)targetPulse * speedFeedForwardGain;
+	/* sgn(v) をデッドバンド付きで算出 */
+	if (targetSpeed_mm_s > SPEED_FEEDFORWARD_SIGN_DEADBAND_MM_S)
+		sign = 1.0f;
+	else if (targetSpeed_mm_s < -SPEED_FEEDFORWARD_SIGN_DEADBAND_MM_S)
+		sign = -1.0f;
+	else
+		sign = 0.0f;
 
-	/* フィードフォワードで加算するPWM値を安全範囲に制限 */
-	if (feedForward > 1000)
-		feedForward = 1000;
-	else if (feedForward < -1000)
-		feedForward = -1000;
+	/* Kv_ff(G) = G*60/(π D Kv) [V/(mm/s)] */
+	kv_ff = SPEED_FEEDFORWARD_GEAR_RATIO * 60.0f /
+		((float)M_PI * SPEED_FEEDFORWARD_WHEEL_DIAMETER_MM * SPEED_FEEDFORWARD_KV_RPM_PER_V);
+	/* τ_wheel_per[mNm] = (Crr*m*g*(D/2)/2)*1000 */
+	wheelDiameter_m = SPEED_FEEDFORWARD_WHEEL_DIAMETER_MM * 0.001f;
+	tau_wheel_per_mNm = (crr * SPEED_FEEDFORWARD_MASS_KG * SPEED_FEEDFORWARD_GRAVITY * (wheelDiameter_m / 2.0f) / 2.0f) * 1000.0f;
+	/* V_bias(G,η) = (S/Kv) * τ_wheel_per / (η*G) */
+	v_bias = (SPEED_FEEDFORWARD_S_RPM_PER_MNM / SPEED_FEEDFORWARD_KV_RPM_PER_V) *
+	         tau_wheel_per_mNm / (SPEED_FEEDFORWARD_EFFICIENCY * SPEED_FEEDFORWARD_GEAR_RATIO);
+	/* Vreq = Kv_ff*v + sgn(v)*V_bias */
+	voltageRequest = (kv_ff * targetSpeed_mm_s) + (sign * v_bias);
+	/* PWM = Vreq / Vbat * PWM_MAX （バッテリ電圧0V時は0とする）*/
+	if (batteryVoltage > 0.0f)
+		pwm = voltageRequest / batteryVoltage * (float)pwm_max;
+	else
+		pwm = 0.0f;
 
-	return (int16_t)feedForward;
+	/* PWM の上限をクリップ */
+	if (pwm > (float)pwm_max)
+		pwm = (float)pwm_max;
+	else if (pwm < -(float)pwm_max)
+		pwm = -(float)pwm_max;
+
+	/* 例: Crr=0.02, η=0.90, Vbat=4.5V, PWM_MAX=1000, v=1000mm/s → PWM≈145 */
+	return (int16_t)pwm;
 }
 
 ///////////////////////////////////////////////////////////////////////////
@@ -54,7 +84,8 @@ static int16_t calcSpeedFeedForward(int16_t targetPulse)
 ///////////////////////////////////////////////////////////////////////////
 void setTargetSpeed(float speed)
 {
-	targetSpeed = (int16_t)(speed * PALSE_MILLIMETER);
+	targetSpeedCommand_m_s = speed;	// フィードフォワード計算へ引き渡す速度指令値[m/s]を保存
+	targetSpeed = (int16_t)(speed * PALSE_MILLIMETER);	// 速度指令値[m/s]をエンコーダ換算値へ変換
 }
 ///////////////////////////////////////////////////////////////////////////
 // モジュール名 setTargetAngularVelocity
@@ -161,6 +192,8 @@ void motorControlSpeed(void)
 {
 	int32_t iP, iI, iD, iRet, Dev, Dif;
 	int16_t feedForward;
+	float targetSpeed_mm_s;
+	float crr;
 
 	// 駆動モーター用PWM値計算
 	Dev = (int16_t)targetSpeed - encCurrentN; // 偏差
@@ -174,7 +207,12 @@ void motorControlSpeed(void)
 	iP = veloCtrl.kp * Dev;		         // 比例
 	iI = veloCtrl.ki * veloCtrl.Int; // 積分
 	iD = veloCtrl.kd * Dif;		         // 微分
-	feedForward = calcSpeedFeedForward((int16_t)targetSpeed); // フィードフォワード項
+	// 物理パラメータを用いてフィードフォワード電圧を算出
+	targetSpeed_mm_s = targetSpeedCommand_m_s * 1000.0f;	// setTargetSpeedで保持した[m/s]を[mm/s]へ換算
+	/* control.cで計測済みのバッテリ電圧[V]を使用 */
+	crr = (float)speedFeedForwardGain * SPEED_FEEDFORWARD_CRR_SCALE; // 転がり抵抗係数Crr
+	feedForward = calcSpeedFeedForward(targetSpeed_mm_s, batteryVoltage_V,
+			SPEED_FEEDFORWARD_PWM_MAX_DEFAULT, crr); // フィードフォワード項
 	// PID制御出力にフィードフォワード補償を加えて応答を改善
 	iRet = iP + iI + iD + feedForward;
 	iRet = iRet;

--- a/robotrace_v2/Core/Src/PIDcontrol.c
+++ b/robotrace_v2/Core/Src/PIDcontrol.c
@@ -15,7 +15,7 @@ pidParam distCtrl = {"dist", KP5, KI5, KD5, 0, 0};
 // 速度フィードフォワード係数(セットアップ画面から変更可能: Crr×1000)
 int16_t speedFeedForwardGain = SPEED_FEEDFORWARD_GAIN_DEFAULT;
 
-uint8_t targetSpeed;		 // 目標速度
+uint8_t targetSpeed = 0;		 // 目標速度（初期値0）
 float targetSpeedCommand_m_s;	// setTargetSpeedで指定した速度指令値[m/s]
 float targetAngle;			 // 目標角速度
 float targetAngularVelocity; // 目標角度
@@ -192,24 +192,21 @@ void motorControlSpeed(void)
 {
 	int32_t iP, iI, iD, iRet, Dev, Dif;
 	static int16_t feedForwardPwm = 0;	/* フィードフォワードPWM値を保持して再利用 */
-	static uint8_t feedForwardInitialized = 0;	/* 初回実行でフィードフォワードを計算したかのフラグ */
 	float targetSpeed_mm_s;
 	float crr;
 
 	// 駆動モーター用PWM値計算
 	Dev = (int16_t)targetSpeed - encCurrentN; // 偏差
 	// 目標値を変更したタイミングで積分項リセットとフィードフォワード更新を同時に実施
-	if ((targetSpeed != speedTargetBefore) || !feedForwardInitialized)
+	if (targetSpeed != speedTargetBefore)
 	{
-		if (targetSpeed != speedTargetBefore)
-			veloCtrl.Int = 0;	/* 目標値変更時に積分項をリセット */
+		veloCtrl.Int = 0;	/* 目標値変更時に積分項をリセット */
 		// 物理パラメータを用いてフィードフォワード電圧を算出
 		targetSpeed_mm_s = targetSpeedCommand_m_s * 1000.0f;	// setTargetSpeedで保持した[m/s]を[mm/s]へ換算
 		/* control.cで計測済みのバッテリ電圧[V]を使用 */
 		crr = (float)speedFeedForwardGain * SPEED_FEEDFORWARD_CRR_SCALE;	// 転がり抵抗係数Crr
 		feedForwardPwm = calcSpeedFeedForward(targetSpeed_mm_s, batteryVoltage_V,
 				SPEED_FEEDFORWARD_PWM_MAX_DEFAULT, crr);	// フィードフォワード項
-		feedForwardInitialized = 1;	/* 更新済みを記録 */
 	}
 
 	veloCtrl.Int += (float)Dev * 0.001;	// 時間積分

--- a/robotrace_v2/Core/Src/PIDcontrol.c
+++ b/robotrace_v2/Core/Src/PIDcontrol.c
@@ -198,27 +198,26 @@ void motorControlSpeed(void)
 
 	// 駆動モーター用PWM値計算
 	Dev = (int16_t)targetSpeed - encCurrentN; // 偏差
-	// 目標値を変更したらI成分リセット
-	if (targetSpeed != speedTargetBefore)
-		veloCtrl.Int = 0;
-
-	veloCtrl.Int += (float)Dev * 0.001; // 時間積分
-	Dif = Dev - speedEncoderBefore;		  // 微分　dゲイン1/1000倍
-
-	iP = veloCtrl.kp * Dev;		  // 比例
-	iI = veloCtrl.ki * veloCtrl.Int; // 積分
-	iD = veloCtrl.kd * Dif;		  // 微分
-	// 目標値が変化したタイミングのみフィードフォワード値を更新
+	// 目標値を変更したタイミングで積分項リセットとフィードフォワード更新を同時に実施
 	if ((targetSpeed != speedTargetBefore) || !feedForwardInitialized)
 	{
+		if (targetSpeed != speedTargetBefore)
+			veloCtrl.Int = 0;	/* 目標値変更時に積分項をリセット */
 		// 物理パラメータを用いてフィードフォワード電圧を算出
 		targetSpeed_mm_s = targetSpeedCommand_m_s * 1000.0f;	// setTargetSpeedで保持した[m/s]を[mm/s]へ換算
 		/* control.cで計測済みのバッテリ電圧[V]を使用 */
 		crr = (float)speedFeedForwardGain * SPEED_FEEDFORWARD_CRR_SCALE;	// 転がり抵抗係数Crr
 		feedForwardPwm = calcSpeedFeedForward(targetSpeed_mm_s, batteryVoltage_V,
 				SPEED_FEEDFORWARD_PWM_MAX_DEFAULT, crr);	// フィードフォワード項
-		feedForwardInitialized = 1; /* 更新済みを記録 */
+		feedForwardInitialized = 1;	/* 更新済みを記録 */
 	}
+
+	veloCtrl.Int += (float)Dev * 0.001;	// 時間積分
+	Dif = Dev - speedEncoderBefore;		// 微分　dゲイン1/1000倍
+
+	iP = veloCtrl.kp * Dev;		// 比例
+	iI = veloCtrl.ki * veloCtrl.Int; // 積分
+	iD = veloCtrl.kd * Dif;		// 微分
 	// PID制御出力にフィードフォワード補償を加えて応答を改善
 	iRet = iP + iI + iD + feedForwardPwm;
 	iRet = iRet;

--- a/robotrace_v2/Core/Src/control.c
+++ b/robotrace_v2/Core/Src/control.c
@@ -259,8 +259,7 @@ void initSystem(void)
 	resetCycleCounter();
 	enableCycleCounter(); // カウント開始
 
-	/* DWT初期化直後にバッテリ電圧[V]を取得して以後の処理で共有 */
-	batteryVoltage_V = AD2VOLTAGE(batteryAD);
+	batteryVoltage_V = AD2VOLTAGE(batteryAD); // バッテリ電圧を計算
 
 	encClick = 0; // ホイールクリッククリア
 

--- a/robotrace_v2/Core/Src/control.c
+++ b/robotrace_v2/Core/Src/control.c
@@ -3,6 +3,7 @@
 //====================================//
 #include "control.h"
 #include "fatfs.h"
+#include "battery.h"
 //====================================//
 // グローバル変数の宣言
 //====================================//
@@ -21,6 +22,7 @@ int16_t autoStartAnalize = 0; // 自動走行で使用するログの解析番�
 
 uint16_t analogVal1[NUM_SENSORS]; // ADC結果格納配列
 uint16_t analogVal2[4];			  // ADC結果格納配列
+float batteryVoltage_V = 0.0f;	// DWT初期化後に取得したバッテリ電圧[V]を保持
 
 // 速度パラメータ関連
 speedParam tgtParam = {
@@ -256,6 +258,9 @@ void initSystem(void)
 	initCycleCounter();
 	resetCycleCounter();
 	enableCycleCounter(); // カウント開始
+
+	/* DWT初期化直後にバッテリ電圧[V]を取得して以後の処理で共有 */
+	batteryVoltage_V = AD2VOLTAGE(batteryAD);
 
 	encClick = 0; // ホイールクリッククリア
 


### PR DESCRIPTION
## 概要
- DWT初期化直後にバッテリ電圧を計測して共有するグローバル変数を追加しました
- 速度制御のフィードフォワード計算で共有済みのバッテリ電圧を参照するよう更新しました

## テスト
- 未実施（ハードウェア依存）

------
https://chatgpt.com/codex/tasks/task_e_68e2390019e0832399a71700507b135d