### PR TITLE
ライン偏差ベースの角速度カスケード制御を導入

### DIFF
--- a/robotrace_v2/Core/Inc/PIDcontrol.h
+++ b/robotrace_v2/Core/Inc/PIDcontrol.h
@@ -80,6 +80,7 @@ extern int16_t speedFeedForwardGain;
 //====================================//
 void setTargetSpeed (float speed);
 void setTargetAngularVelocity (float angularVelocity);
+void setLineTraceCascadeEnabled (bool enable);
 void setTargetAngle (float angle);
 void setTargetDist (float dist);
 void resetSpeedPID (void);

--- a/robotrace_v2/Core/Src/PIDcontrol.c
+++ b/robotrace_v2/Core/Src/PIDcontrol.c
@@ -15,6 +15,8 @@ pidParam distCtrl = {"dist", KP5, KI5, KD5, 0, 0};
 // 速度フィードフォワード係数(セットアップ画面から変更可能: Crr×1000)
 int16_t speedFeedForwardGain = SPEED_FEEDFORWARD_GAIN_DEFAULT;
 
+static bool lineTraceCascadeEnabled = false;
+
 uint8_t targetSpeed = 0;		 // 目標速度（初期値0）
 float targetSpeedCommand_m_s;	// setTargetSpeedで指定した速度指令値[m/s]
 float targetAngle;			 // 目標角速度
@@ -95,7 +97,17 @@ void setTargetSpeed(float speed)
 ///////////////////////////////////////////////////////////////////////////
 void setTargetAngularVelocity(float angularVelocity)
 {
-	targetAngularVelocity = angularVelocity;
+        targetAngularVelocity = angularVelocity;
+}
+///////////////////////////////////////////////////////////////////////////
+// モジュール名 setLineTraceCascadeEnabled
+// 処理概要     ライントレース由来の角速度目標設定を有効/無効化
+// 引数         enable:trueで有効
+// 戻り値       なし
+///////////////////////////////////////////////////////////////////////////
+void setLineTraceCascadeEnabled(bool enable)
+{
+        lineTraceCascadeEnabled = enable;
 }
 ///////////////////////////////////////////////////////////////////////////
 // モジュール名 setTargetAngle
@@ -181,6 +193,11 @@ void motorControlTrace(void)
 
 	lineTraceCtrl.pwm = iRet;
 	traceBefore = Dev; // 次回はこの値が1ms前の値となる
+	if (lineTraceCascadeEnabled)
+	{
+		// ラインセンサ偏差に基づき角速度目標を更新しカスケード制御の外側ループを構成
+		setTargetAngularVelocity((float)lineTraceCtrl.pwm);
+	}
 }
 ///////////////////////////////////////////////////////////////////////////
 // モジュール名 motorControlSpeed

--- a/robotrace_v2/Core/Src/control.c
+++ b/robotrace_v2/Core/Src/control.c
@@ -430,9 +430,10 @@ void loopSystem(void)
 
 	case 11:
 		// スタートマーカー通過までの走行
+		setLineTraceCascadeEnabled(true); // カスケード制御でライン偏差から角速度を生成
 		setTargetSpeed(tgtParam.straight); // 目標速度
 		// ライントレース
-		motorPwmOutSynth(lineTraceCtrl.pwm, veloCtrl.pwm, 0, 0);
+		motorPwmOutSynth(0, veloCtrl.pwm, yawRateCtrl.pwm, 0);
 
 		// スタートマーカーを通過したら本走行に移行
 		if (SGmarker > 0)
@@ -457,13 +458,14 @@ void loopSystem(void)
 			{
 				modeLOG = true; // log start
 			}
-			
+
 			patternTrace = 12;
 		}
 		break;
 
 	case 12:
 		// 目標速度設定
+		setLineTraceCascadeEnabled(true); // 角速度外側ループを継続
 		if (optimalTrace == BOOST_NONE)
 		{
 			// 探索走行のとき
@@ -476,7 +478,7 @@ void loopSystem(void)
 				setTargetSpeed(tgtParam.curve);
 			}
 			// ライントレース
-			motorPwmOutSynth(lineTraceCtrl.pwm, veloCtrl.pwm, 0, 0);
+			motorPwmOutSynth(0, veloCtrl.pwm, yawRateCtrl.pwm, 0);
 		}
 		else if (optimalTrace == BOOST_DISTANCE)
 		{
@@ -492,7 +494,7 @@ void loopSystem(void)
 				if (encTotalOptimal - DistanceOptimal >= encMM(CALCDISTANCE))
 				{
 					boostSpeed = PPAD[optimalIndex].boostSpeed; // 目標速度を更新
-					DistanceOptimal = encTotalOptimal;			// 距離計測位置を更新
+					DistanceOptimal = encTotalOptimal;                      // 距離計測位置を更新
 					if (optimalIndex + 1 < numPPADarry)
 					{
 						// 配列要素数を超えない範囲でインデックスを更新する
@@ -507,7 +509,7 @@ void loopSystem(void)
 			// 目標速度に設定
 			setTargetSpeed(boostSpeed);
 			// ライントレース
-			motorPwmOutSynth(lineTraceCtrl.pwm, veloCtrl.pwm, 0, 0);
+			motorPwmOutSynth(0, veloCtrl.pwm, yawRateCtrl.pwm, 0);
 		}
 		else if (optimalTrace == BOOST_SHORTCUT)
 		{
@@ -547,11 +549,10 @@ void loopSystem(void)
 			}
 		}
 		break;
-
 	case 101:
 		if (modeDSP && !ssd1306_IsDMARunning())
 		{
-			ssd1306_UpdateScreen_DMA();        // 停止していた画面更新を再開
+			ssd1306_UpdateScreen_DMA();	// 停止していた画面更新を再開
 		}
 		// 停止速度まで減速
 		if (enc1 >= encMM(200))
@@ -562,16 +563,16 @@ void loopSystem(void)
 		{
 			setTargetSpeed(tgtParam.stop);
 		}
-		motorPwmOutSynth(lineTraceCtrl.pwm, veloCtrl.pwm, 0, 0);
+		motorPwmOutSynth(0, veloCtrl.pwm, yawRateCtrl.pwm, 0);
 
 		if (encCurrentN == 0)
 		{
 			patternTrace = 102;
 		}
 		break;
-
 	case 102:
 		setTargetSpeed(0);
+		setLineTraceCascadeEnabled(false); // 走行終了時はライン由来の角速度指令を停止
 		motorPwmOutSynth(0, 0, 0, 0);
 
 		if (modeLOG)
@@ -607,10 +608,10 @@ void loopSystem(void)
 				tgtParam.bst700 *= PARAM_UP_STEP;
 				tgtParam.bst600 *= PARAM_UP_STEP;
 				tgtParam.bst500 *= PARAM_UP_STEP;
-				// tgtParam.bst400			*= PARAM_UP_STEP;
-				// tgtParam.bst300			*= PARAM_UP_STEP;
-				// tgtParam.bst200			*= PARAM_UP_STEP;
-				// tgtParam.bst100			*= PARAM_UP_STEP;
+				// tgtParam.bst400                      *= PARAM_UP_STEP;
+				// tgtParam.bst300                      *= PARAM_UP_STEP;
+				// tgtParam.bst200                      *= PARAM_UP_STEP;
+				// tgtParam.bst100                      *= PARAM_UP_STEP;
 			}
 
 			if (autoStart > 5)
@@ -644,9 +645,9 @@ void loopSystem(void)
 				if (logOverflow || markerOverflow)
 				{
 					// バッファ上限エラー表示
-					ssd1306_SetCursor(0, 25);						// 1行目の表示位置
+					ssd1306_SetCursor(0, 25);						 // 1行目の表示位置
 					ssd1306_printf(Font_11x18, "buff overflow");	// エラーメッセージ1行目
-					ssd1306_SetCursor(0, 45);						// 2行目の表示位置
+					ssd1306_SetCursor(0, 45);						 // 2行目の表示位置
 					ssd1306_printf(Font_11x18, "error");			// エラーメッセージ2行目
 				}
 				else
@@ -661,7 +662,6 @@ void loopSystem(void)
 
 		patternTrace = 103;
 		break;
-
 	case 103:
 		motorPwmOutSynth(0, 0, 0, 0);
 		powerLineSensors(0);


### PR DESCRIPTION
## Summary
- ラインセンサ偏差から角速度目標を生成するカスケード制御を実装
- 角速度カスケードの有効/無効切替APIを追加し、走行シーケンスで制御
- メジャーループの角速度PID出力を速度制御と合成してモータに適用

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e51ddc48008323b09bc627ee9bbacc